### PR TITLE
Fix validation in the CRD definition

### DIFF
--- a/config/crd/bases/database.marklogic.com_marklogicclusters.yaml
+++ b/config/crd/bases/database.marklogic.com_marklogicclusters.yaml
@@ -11004,7 +11004,7 @@ spec:
             - message: HAProxy and Pathbased Routing is enabled. PathBasedRouting
                 is only supported for MarkLogic 11.1 and above
               rule: '!(self.haproxy.enabled == true && self.haproxy.pathBasedRouting
-                == true) || int(self.image.split('':'')[1].split(''.'')[0] + self.image.split('':'')[1].split(''.'')[1])
+                == true) || int(self.image.split('':'')[size(self.image.split('':'')) - 1].split(''.'')[0] + self.image.split('':'')[size(self.image.split('':'')) - 1].split(''.'')[1]) 
                 >= 111'
           status:
             description: MarklogicClusterStatus defines the observed state of MarklogicCluster


### PR DESCRIPTION
The validation fails to work when the image string has more than one ":". The validation failed when I tried to pull the marklogic image from an internal registry runnong on port 5000.
