### PR TITLE
MLE-28364 : add specific E2E for helm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -237,7 +237,7 @@ pipeline {
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
         booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
-        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: true, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,7 +275,7 @@ pipeline {
 
         stage('Istio-Minikube-Setup') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT }
+                expression { return params.VERIFY_ISTIO_AMBIENT != false }
             }
             steps {
                 runIstioMinikubeSetup()
@@ -284,7 +284,7 @@ pipeline {
 
         stage('Run-Istio-e2e-Tests') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT }
+                expression { return params.VERIFY_ISTIO_AMBIENT != false }
             }
             steps {
                 runIstioE2eTests()
@@ -293,7 +293,7 @@ pipeline {
 
         stage('Istio-Cleanup') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT }
+                expression { return params.VERIFY_ISTIO_AMBIENT != false }
             }
             steps {
                 runMinikubeCleanup()
@@ -302,7 +302,7 @@ pipeline {
 
         stage('Helm-NS-Minikube-Setup') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false }
             }
             steps {
                 runMinikubeSetup()
@@ -311,7 +311,7 @@ pipeline {
 
         stage('Run-Helm-NS-e2e-Tests') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false }
             }
             steps {
                 runHelmNamespaceScopedE2eTests()
@@ -320,7 +320,7 @@ pipeline {
 
         stage('Helm-NS-Cleanup') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false }
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,12 @@ void runIstioE2eTests() {
     """
 }
 
+void runHelmNamespaceScopedE2eTests() {
+    sh """
+        make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
+    """
+}
+
 void runBlackDuckScan() {
     // Trigger BlackDuck scan job with CONTAINER_IMAGES parameter when params.PUBLISH_IMAGE is true
     if (params.PUBLISH_IMAGE) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,12 @@ void runIstioE2eTests() {
     """
 }
 
+void runHelmNamespaceScopedE2eTests() {
+    sh """
+        make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
+    """
+}
+
 void runBlackDuckScan() {
     // Trigger BlackDuck scan job with CONTAINER_IMAGES parameter when params.PUBLISH_IMAGE is true
     if (params.PUBLISH_IMAGE) {
@@ -212,9 +218,9 @@ pipeline {
     
     triggers {
         // Trigger nightly builds on the develop branch
-        parameterizedCron( env.BRANCH_NAME == 'develop' ? '''00 05 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-12
-                                                             00 05 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-11; PUBLISH_IMAGE=false
-                                                             00 07 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-12; VERIFY_ISTIO_AMBIENT=true''' : '')
+        parameterizedCron( env.BRANCH_NAME == 'develop' ? '''00 05 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-12; VERIFY_HELM_NAMESPACE_SCOPED=true
+                                                             00 05 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-11; PUBLISH_IMAGE=false; VERIFY_HELM_NAMESPACE_SCOPED=true
+                                                             00 07 * * * % E2E_MARKLOGIC_IMAGE_VERSION=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-12; VERIFY_ISTIO_AMBIENT=true; VERIFY_HELM_NAMESPACE_SCOPED=true''' : '')
     }
 
     environment {
@@ -231,6 +237,7 @@ pipeline {
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
         booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
     stages {
@@ -290,6 +297,35 @@ pipeline {
             }
             steps {
                 runMinikubeCleanup()
+            }
+        }
+
+        stage('Helm-NS-Minikube-Setup') {
+            when {
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
+            steps {
+                runMinikubeSetup()
+            }
+        }
+
+        stage('Run-Helm-NS-e2e-Tests') {
+            when {
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
+            steps {
+                runHelmNamespaceScopedE2eTests()
+            }
+        }
+
+        stage('Helm-NS-Cleanup') {
+            when {
+                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    runMinikubeCleanup()
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,7 +236,8 @@ pipeline {
         string(name: 'VERSION', defaultValue: '1.2.0', description: 'Version to tag the image with.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
-        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: false, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_E2E', defaultValue: false, description: 'Run standard cluster-scoped e2e tests')
         booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: true, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
@@ -254,18 +255,27 @@ pipeline {
         }
 
         stage('Run-Minikube-Setup') {
+            when {
+                expression { return params.VERIFY_E2E }
+            }
             steps {
                 runMinikubeSetup()
             }
         }
 
         stage('Run-e2e-Tests') {
+            when {
+                expression { return params.VERIFY_E2E }
+            }
             steps {
                 runE2eTests()
             }
         }
 
         stage('Cleanup Environment') {
+            when {
+                expression { return params.VERIFY_E2E }
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     runMinikubeCleanup()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,9 +137,9 @@ void runMinikubeSetup() {
     """
 }
 
-void runE2eTests(String scope = 'cluster') {
+void runE2eTests() {
     sh """
-        make e2e-test-${scope} IMG=${operatorRepo}:${VERSION}
+        make e2e-test IMG=${operatorRepo}:${VERSION}
     """
 }
 
@@ -158,12 +158,6 @@ void runIstioMinikubeSetup() {
 void runIstioE2eTests() {
     sh """
         make e2e-test-istio IMG=${operatorRepo}:${VERSION} E2E_ISTIO_AMBIENT=true
-    """
-}
-
-void runHelmNamespaceScopedE2eTests() {
-    sh """
-        make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
     """
 }
 
@@ -236,9 +230,8 @@ pipeline {
         string(name: 'VERSION', defaultValue: '1.2.0', description: 'Version to tag the image with.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
-        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: false, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
-        booleanParam(name: 'VERIFY_E2E', defaultValue: false, description: 'Run standard cluster-scoped e2e tests')
-        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: true, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
     stages {
@@ -255,27 +248,18 @@ pipeline {
         }
 
         stage('Run-Minikube-Setup') {
-            when {
-                expression { return params.VERIFY_E2E }
-            }
             steps {
                 runMinikubeSetup()
             }
         }
 
         stage('Run-e2e-Tests') {
-            when {
-                expression { return params.VERIFY_E2E }
-            }
             steps {
                 runE2eTests()
             }
         }
 
         stage('Cleanup Environment') {
-            when {
-                expression { return params.VERIFY_E2E }
-            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     runMinikubeCleanup()
@@ -285,7 +269,7 @@ pipeline {
 
         stage('Istio-Minikube-Setup') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT != false }
+                expression { return params.VERIFY_ISTIO_AMBIENT }
             }
             steps {
                 runIstioMinikubeSetup()
@@ -294,7 +278,7 @@ pipeline {
 
         stage('Run-Istio-e2e-Tests') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT != false }
+                expression { return params.VERIFY_ISTIO_AMBIENT }
             }
             steps {
                 runIstioE2eTests()
@@ -303,7 +287,7 @@ pipeline {
 
         stage('Istio-Cleanup') {
             when {
-                expression { return params.VERIFY_ISTIO_AMBIENT != false }
+                expression { return params.VERIFY_ISTIO_AMBIENT }
             }
             steps {
                 runMinikubeCleanup()

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,11 @@ e2e-test-cluster:
 	@echo "=====Running e2e tests in cluster-scoped mode"
 	E2E_SCOPE_TYPE=cluster go test -v -count=1 -timeout 30m ./test/e2e
 
+.PHONY: e2e-test-helm-namespace  ## Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)
+e2e-test-helm-namespace:
+	@echo "=====Running namespace-scoped e2e tests via Helm chart====="
+	go test -v -count=1 -timeout 45m ./test/e2e-helm
+
 .PHONY: e2e-setup-minikube
 e2e-setup-minikube: kustomize controller-gen build docker-build
 	minikube version

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ e2e-test-cluster:
 .PHONY: e2e-test-helm-namespace  ## Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)
 e2e-test-helm-namespace:
 	@echo "=====Running namespace-scoped e2e tests via Helm chart====="
-	go test -v -count=1 -timeout 45m ./test/e2e-helm
+	E2E_DOCKER_IMAGE=$(IMG) go test -v -count=1 -timeout 45m ./test/e2e-helm
 
 .PHONY: e2e-setup-minikube
 e2e-setup-minikube: kustomize controller-gen build docker-build

--- a/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
@@ -100,6 +100,9 @@ subjects:
 {{- /*
 Namespace-scoped mode: Role + RoleBinding created in each watched namespace.
 Supports a single name, a comma-separated string, or a YAML list.
+The operator's own namespace (.Release.Namespace) is always included because
+cmd/main.go adds it to the controller-runtime cache DefaultNamespaces for
+leader-election and CRD informer syncing.
 */}}
 {{- $namespaces := list }}
 {{- if .Values.scope.watchNamespaces }}
@@ -112,6 +115,10 @@ Supports a single name, a comma-separated string, or a YAML list.
   {{- end }}
 {{- else }}
   {{- $namespaces = list .Release.Namespace }}
+{{- end }}
+{{- /* Always include the operator's own namespace so its cache can watch CRs there */}}
+{{- if not (has .Release.Namespace $namespaces) }}
+  {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 {{- range $ns := $namespaces }}
 ---

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -325,6 +325,9 @@ subjects:
 {{- /*
 Namespace-scoped mode: Role + RoleBinding created in each watched namespace.
 Supports a single name, a comma-separated string, or a YAML list.
+The operator's own namespace (.Release.Namespace) is always included because
+cmd/main.go adds it to the controller-runtime cache DefaultNamespaces for
+leader-election and CRD informer syncing.
 */}}
 {{- $namespaces := list }}
 {{- if .Values.scope.watchNamespaces }}
@@ -337,6 +340,10 @@ Supports a single name, a comma-separated string, or a YAML list.
   {{- end }}
 {{- else }}
   {{- $namespaces = list .Release.Namespace }}
+{{- end }}
+{{- /* Always include the operator's own namespace so its cache can watch CRs there */}}
+{{- if not (has .Release.Namespace $namespaces) }}
+  {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 {{- range $ns := $namespaces }}
 ---

--- a/test/README.md
+++ b/test/README.md
@@ -1,22 +1,106 @@
 # Test MarkLogic Kubernetes Operator with e2e-framework
 
-## How to run the test
+## Test suites
+
+| Package | Description |
+|---|---|
+| `test/e2e` | Cluster-scoped tests. Operator deployed via `make deploy` (kustomize, ClusterRole/ClusterRoleBinding). |
+| `test/e2e-helm` | Namespace-scoped tests. Operator installed via `helm install` with `scope.type=namespace`. Validates that Role/RoleBinding per watched namespace is sufficient and no ClusterRole is present. |
+
+---
+
+## test/e2e — Cluster-scoped
+
+### Setup and run
 
 ```
 make e2e-setup-minikube
 make e2e-test
-make e2e-delete-minikube
+make e2e-cleanup-minikube
 ```
 
-## Run Specific Test Types
-Each test is assigned a “type” label, allowing you to run only the tests of a specified type.
+### Run in specific scope mode
 
-For example, to run only the test for TLS named cert test:
+```bash
+# Cluster-scoped (default)
+make e2e-test-cluster
+
+# Namespace-scoped (patches WATCH_NAMESPACE at runtime; metrics.secure forced to false)
+make e2e-test-namespace
 ```
+
+### Run specific test types
+
+Each test is assigned a `type` label, allowing you to run only tests of that type.
+
+```bash
+# TLS named cert
 go test -v ./test/e2e -count=1 -args --labels="type=tls-named-cert"
+
+# TLS self-signed cert
+go test -v ./test/e2e -count=1 -args --labels="type=tls-self-signed"
+
+# HAProxy path-based routing
+go test -v ./test/e2e -count=1 -args --labels="type=haproxy-pathbased-enabled"
+
+# Metrics endpoint
+go test -v ./test/e2e -count=1 -args --labels="type=metrics"
 ```
 
-To run only the TLS self signed cert test:
+---
+
+## test/e2e-helm — Namespace-scoped (Helm)
+
+This suite installs the operator via the Helm chart with `scope.type=namespace` so the operator
+runs with only a Role/RoleBinding per watched namespace — no ClusterRole backstop.
+It is the only reliable way to validate namespace-scoped RBAC behaviour.
+
+### Setup and run
+
 ```
-go test -v ./test/e2e -count=1 -args --labels="type=tls-self-signed"
+make e2e-setup-minikube
+make e2e-test-helm-namespace
+make e2e-cleanup-minikube
+```
+
+Or run directly (requires a running cluster with `helm` in PATH):
+
+```
+go test -v -count=1 -timeout 45m ./test/e2e-helm
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `E2E_DOCKER_IMAGE` | _(none)_ | Operator image (`repo:tag`). If set, loaded into minikube with `pullPolicy=Never`. |
+| `E2E_MARKLOGIC_IMAGE_VERSION` | _(none)_ | MarkLogic server image used in all CRs. |
+
+### Watched namespaces
+
+The Helm chart is installed with:
+
+```
+scope.watchNamespaces=ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log
+```
+
+All test namespaces must appear in this list. The operator has no RBAC outside these namespaces.
+
+### Run specific test types
+
+```bash
+# RBAC validation (ClusterRole absent, Role/RoleBinding present per namespace)
+go test -v ./test/e2e-helm -count=1 -args --labels="type=rbac"
+
+# Namespace-scoped cluster reconciliation
+go test -v ./test/e2e-helm -count=1 -args --labels="type=cluster-ns"
+
+# dnode + enode two-group cluster
+go test -v ./test/e2e-helm -count=1 -args --labels="type=ednode"
+
+# TLS self-signed
+go test -v ./test/e2e-helm -count=1 -args --labels="type=tls-self-signed"
+
+# Metrics endpoint (insecure HTTP, no auth)
+go test -v ./test/e2e-helm -count=1 -args --labels="type=metrics"
 ```

--- a/test/e2e-helm/1_operator_ready_test.go
+++ b/test/e2e-helm/1_operator_ready_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// TestOperatorReady verifies that the Helm-installed operator is running correctly:
+// the CRD is registered and the controller-manager pod is present and owned by the
+// marklogic-operator Deployment.
+func TestOperatorReady(t *testing.T) {
+	podCreationSig := make(chan *corev1.Pod, 1)
+	done := make(chan struct{})
+
+	feature := features.New("Operator Ready (Helm Namespace-Scoped)").
+		WithLabel("type", "operator-ready")
+
+	feature.Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		client := cfg.Client()
+
+		if err := client.Resources(helmNS).Watch(&corev1.PodList{}).WithAddFunc(func(obj interface{}) {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				return
+			}
+			if strings.HasPrefix(pod.Name, "marklogic-operator-controller") {
+				select {
+				case podCreationSig <- pod:
+				case <-done:
+				}
+			}
+		}).Start(ctx); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("CRD installed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		apiextensionsv1.AddToScheme(client.Resources().GetScheme())
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err := client.Resources().Get(ctx, "marklogicclusters.marklogic.progress.com", "", &crd); err != nil {
+			t.Fatalf("CRD not found: %v", err)
+		}
+		if crd.Spec.Names.Kind != "MarklogicCluster" {
+			t.Fatalf("CRD has unexpected kind: %s", crd.Spec.Names.Kind)
+		}
+		return ctx
+	})
+
+	feature.Assess("Controller-manager pod running", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		select {
+		case <-time.After(60 * time.Second):
+			t.Error("Timed out waiting for controller-manager pod")
+		case pod := <-podCreationSig:
+			t.Logf("Controller-manager pod observed: %s", pod.Name)
+			if len(pod.OwnerReferences) == 0 {
+				t.Fatalf("Pod %s has no owner references", pod.Name)
+			}
+			ownerName := pod.OwnerReferences[0].Name
+			if !strings.Contains(ownerName, "marklogic-operator") {
+				t.Fatalf("Pod owner %q does not match expected prefix", ownerName)
+			}
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		close(done)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/1_operator_ready_test.go
+++ b/test/e2e-helm/1_operator_ready_test.go
@@ -18,6 +18,7 @@ import (
 // the CRD is registered and the controller-manager pod is present and owned by the
 // marklogic-operator Deployment.
 func TestOperatorReady(t *testing.T) {
+	trackTest(t)
 	podCreationSig := make(chan *corev1.Pod, 1)
 	done := make(chan struct{})
 

--- a/test/e2e-helm/1_operator_ready_test.go
+++ b/test/e2e-helm/1_operator_ready_test.go
@@ -27,6 +27,22 @@ func TestOperatorReady(t *testing.T) {
 	feature.Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		client := cfg.Client()
 
+		// The operator was deployed by TestMain before this test runs, so the pod may
+		// already exist. A Watch only fires for future Add events and will miss it.
+		var podList corev1.PodList
+		if err := client.Resources(helmNS).List(ctx, &podList); err == nil {
+			for i := range podList.Items {
+				if strings.HasPrefix(podList.Items[i].Name, "marklogic-operator-controller") {
+					select {
+					case podCreationSig <- &podList.Items[i]:
+					case <-done:
+					}
+					return ctx
+				}
+			}
+		}
+
+		// If not yet visible, fall back to a Watch for the pod Add event.
 		if err := client.Resources(helmNS).Watch(&corev1.PodList{}).WithAddFunc(func(obj interface{}) {
 			pod, ok := obj.(*corev1.Pod)
 			if !ok {

--- a/test/e2e-helm/2_marklogic_cluster_test.go
+++ b/test/e2e-helm/2_marklogic_cluster_test.go
@@ -58,8 +58,28 @@ func TestMarklogicClusterNamespaceScoped(t *testing.T) {
 	// Create the watched test namespace.
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mlNsTestNS}}
-		if err := client.Resources().Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, mlNsTestNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", mlNsTestNS, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", mlNsTestNS)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", mlNsTestNS, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: mlNsTestNS, Labels: namespaceLabels()},
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
 			t.Fatalf("Failed to create namespace %s: %v", mlNsTestNS, err)
 		}
 		return ctx

--- a/test/e2e-helm/2_marklogic_cluster_test.go
+++ b/test/e2e-helm/2_marklogic_cluster_test.go
@@ -117,6 +117,7 @@ func TestMarklogicClusterNamespaceScoped(t *testing.T) {
 	feature.Assess("MarklogicCluster pod running", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
 		if err := utils.WaitForPod(ctx, t, client, mlNsTestNS, "node-0", 240*time.Second, true); err != nil {
+			logDiagnostics(t, mlNsTestNS)
 			t.Fatalf("Pod node-0 not ready: %v", err)
 		}
 		return ctx

--- a/test/e2e-helm/2_marklogic_cluster_test.go
+++ b/test/e2e-helm/2_marklogic_cluster_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// mlNsTestNS is listed in watchedNamespaces so the namespace-scoped operator
+// has a Role/RoleBinding here and can reconcile MarklogicCluster resources.
+const mlNsTestNS = "ml-ns-test"
+
+var nsTestCluster = &marklogicv1.MarklogicCluster{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "marklogic.progress.com/v1",
+		Kind:       "MarklogicCluster",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ml-ns-cluster",
+		Namespace: mlNsTestNS,
+	},
+	Spec: marklogicv1.MarklogicClusterSpec{
+		Image: marklogicImage,
+		Auth: &marklogicv1.AdminAuth{
+			AdminUsername: &adminUsername,
+			AdminPassword: &adminPassword,
+		},
+		MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+			{
+				Name:        "node",
+				Replicas:    &replicas,
+				IsBootstrap: true,
+			},
+		},
+	},
+}
+
+// TestMarklogicClusterNamespaceScoped deploys a MarklogicCluster into a watched namespace
+// and verifies the operator reconciles it correctly using only the namespace-scoped
+// Role/RoleBinding installed by the Helm chart (no ClusterRole backstop).
+func TestMarklogicClusterNamespaceScoped(t *testing.T) {
+	feature := features.New("MarklogicCluster — Namespace-Scoped").
+		WithLabel("type", "cluster-ns")
+
+	// Create the watched test namespace.
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mlNsTestNS}}
+		if err := client.Resources().Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", mlNsTestNS, err)
+		}
+		return ctx
+	})
+
+	// Register the MarklogicCluster scheme and deploy the CR.
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources(mlNsTestNS).GetScheme())
+
+		if err := client.Resources(mlNsTestNS).Create(ctx, nsTestCluster); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(nsTestCluster, func(object k8s.Object) bool {
+				return true
+			}),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatalf("MarklogicCluster not created within timeout: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("MarklogicCluster CR exists", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var mc marklogicv1.MarklogicCluster
+		if err := client.Resources().Get(ctx, nsTestCluster.Name, mlNsTestNS, &mc); err != nil {
+			t.Fatalf("MarklogicCluster not found: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("MarklogicCluster pod running", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := utils.WaitForPod(ctx, t, client, mlNsTestNS, "node-0", 240*time.Second, true); err != nil {
+			t.Fatalf("Pod node-0 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(mlNsTestNS).Delete(ctx, nsTestCluster); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mlNsTestNS}}
+		if err := client.Resources().Delete(ctx, ns); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", mlNsTestNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/2_marklogic_cluster_test.go
+++ b/test/e2e-helm/2_marklogic_cluster_test.go
@@ -52,6 +52,7 @@ var nsTestCluster = &marklogicv1.MarklogicCluster{
 // and verifies the operator reconciles it correctly using only the namespace-scoped
 // Role/RoleBinding installed by the Helm chart (no ClusterRole backstop).
 func TestMarklogicClusterNamespaceScoped(t *testing.T) {
+	trackTest(t)
 	feature := features.New("MarklogicCluster — Namespace-Scoped").
 		WithLabel("type", "cluster-ns")
 

--- a/test/e2e-helm/3_rbac_test.go
+++ b/test/e2e-helm/3_rbac_test.go
@@ -26,6 +26,7 @@ import (
 // because make deploy always applies ClusterRole/ClusterRoleBinding regardless of
 // any WATCH_NAMESPACE patch made afterwards.
 func TestNamespaceScopedRBAC(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Namespace-Scoped RBAC").
 		WithLabel("type", "rbac")
 

--- a/test/e2e-helm/3_rbac_test.go
+++ b/test/e2e-helm/3_rbac_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// TestNamespaceScopedRBAC verifies that the Helm chart installs the correct RBAC for
+// namespace-scoped mode and does NOT install cluster-wide permissions.
+//
+// In namespace-scoped mode (scope.type=namespace) the chart must:
+//   - Create a Role in each watched namespace (not a ClusterRole)
+//   - Create a RoleBinding in each watched namespace (not a ClusterRoleBinding)
+//   - NOT install a ClusterRole named "marklogic-operator-manager-role"
+//   - NOT install a ClusterRoleBinding named "marklogic-operator-manager-rolebinding"
+//
+// This is the key test that the kustomize-based suite (test/e2e) cannot perform,
+// because make deploy always applies ClusterRole/ClusterRoleBinding regardless of
+// any WATCH_NAMESPACE patch made afterwards.
+func TestNamespaceScopedRBAC(t *testing.T) {
+	feature := features.New("Namespace-Scoped RBAC").
+		WithLabel("type", "rbac")
+
+	// Verify no ClusterRole for the manager exists.
+	// Helm does not render manager-rbac.yaml when scope.type=namespace.
+	feature.Assess("No ClusterRole installed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var cr rbacv1.ClusterRole
+		err := client.Resources().Get(ctx, "marklogic-operator-manager-role", "", &cr)
+		if err == nil {
+			t.Fatal("ClusterRole 'marklogic-operator-manager-role' exists but must NOT be present in namespace-scoped mode")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("Unexpected error checking for ClusterRole: %v", err)
+		}
+		t.Log("Confirmed: no manager ClusterRole present")
+		return ctx
+	})
+
+	// Verify no ClusterRoleBinding for the manager exists.
+	feature.Assess("No ClusterRoleBinding installed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var crb rbacv1.ClusterRoleBinding
+		err := client.Resources().Get(ctx, "marklogic-operator-manager-rolebinding", "", &crb)
+		if err == nil {
+			t.Fatal("ClusterRoleBinding 'marklogic-operator-manager-rolebinding' exists but must NOT be present in namespace-scoped mode")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("Unexpected error checking for ClusterRoleBinding: %v", err)
+		}
+		t.Log("Confirmed: no manager ClusterRoleBinding present")
+		return ctx
+	})
+
+	// Verify a Role exists in each watched namespace.
+	feature.Assess("Role exists in each watched namespace", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		for _, ns := range strings.Split(watchedNamespaces, ",") {
+			ns = strings.TrimSpace(ns)
+			var role rbacv1.Role
+			if err := client.Resources(ns).Get(ctx, "marklogic-operator-manager-role", ns, &role); err != nil {
+				t.Fatalf("Role 'marklogic-operator-manager-role' not found in namespace %q: %v", ns, err)
+			}
+			t.Logf("Role found in namespace %q", ns)
+		}
+		return ctx
+	})
+
+	// Verify a RoleBinding exists in each watched namespace and its subject points
+	// to the operator ServiceAccount in the operator install namespace (helmNS).
+	feature.Assess("RoleBinding exists in each watched namespace with correct subject", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		for _, ns := range strings.Split(watchedNamespaces, ",") {
+			ns = strings.TrimSpace(ns)
+			var rb rbacv1.RoleBinding
+			if err := client.Resources(ns).Get(ctx, "marklogic-operator-manager-rolebinding", ns, &rb); err != nil {
+				t.Fatalf("RoleBinding 'marklogic-operator-manager-rolebinding' not found in namespace %q: %v", ns, err)
+			}
+			// The subject must reference the SA in the operator install namespace, not the watched namespace.
+			found := false
+			for _, subj := range rb.Subjects {
+				if subj.Kind == "ServiceAccount" && subj.Namespace == helmNS {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("RoleBinding in namespace %q has no ServiceAccount subject in %q (subjects: %v)", ns, helmNS, rb.Subjects)
+			}
+			t.Logf("RoleBinding in namespace %q has correct subject (SA in %q)", ns, helmNS)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -145,6 +145,7 @@ func TestMlClusterWithEdnode(t *testing.T) {
 
 	feature.Assess("dnode-0 pod is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "dnode-0", 120*time.Second, true); err != nil {
+			logDiagnostics(t, edNodeNS)
 			t.Fatalf("dnode-0 not ready: %v", err)
 		}
 		return ctx
@@ -152,6 +153,7 @@ func TestMlClusterWithEdnode(t *testing.T) {
 
 	feature.Assess("enode-0 pod is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "enode-0", 180*time.Second, true); err != nil {
+			logDiagnostics(t, edNodeNS)
 			t.Fatalf("enode-0 not ready: %v", err)
 		}
 		return ctx
@@ -188,6 +190,7 @@ func TestMlClusterWithEdnode(t *testing.T) {
 
 	feature.Assess("dnode-1 pod created after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "dnode-1", 60*time.Second, true); err != nil {
+			logDiagnostics(t, edNodeNS)
 			t.Fatalf("dnode-1 not ready: %v", err)
 		}
 		return ctx
@@ -195,6 +198,7 @@ func TestMlClusterWithEdnode(t *testing.T) {
 
 	feature.Assess("enode-1 pod created after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "enode-1", 120*time.Second, true); err != nil {
+			logDiagnostics(t, edNodeNS)
 			t.Fatalf("enode-1 not ready: %v", err)
 		}
 		return ctx

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -72,6 +72,7 @@ var (
 // TestMlClusterWithEdnode verifies a two-group (dnode + enode) cluster is reconciled
 // correctly in a watched namespace using only Role/RoleBinding RBAC from the Helm chart.
 func TestMlClusterWithEdnode(t *testing.T) {
+	trackTest(t)
 	feature := features.New("MarklogicCluster with 2 MarkLogicGroups (dnode + enode)").
 		WithLabel("type", "ednode")
 

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	e2eutils "sigs.k8s.io/e2e-framework/pkg/utils"
+)
+
+const (
+	edNodeNS     = "ml-ns-ednode" // must be in watchedNamespaces
+	dnodeGrpName = "dnode"
+	enodeGrpName = "enode"
+)
+
+var (
+	edSecretName  = "ml-admin-secrets"
+	edIncrReplica = int32(2)
+	edGroups      = []*marklogicv1.MarklogicGroups{
+		{
+			Name:        dnodeGrpName,
+			Replicas:    &replicas,
+			IsBootstrap: true,
+			GroupConfig: &marklogicv1.GroupConfig{
+				Name:          "dnode",
+				EnableXdqpSsl: true,
+			},
+		},
+		{
+			Name:     enodeGrpName,
+			Replicas: &replicas,
+			GroupConfig: &marklogicv1.GroupConfig{
+				Name:          "enode",
+				EnableXdqpSsl: true,
+			},
+		},
+	}
+	edCluster = &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mlclusterednode",
+			Namespace: edNodeNS,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				SecretName: &edSecretName,
+			},
+			MarkLogicGroups: edGroups,
+		},
+	}
+)
+
+// TestMlClusterWithEdnode verifies a two-group (dnode + enode) cluster is reconciled
+// correctly in a watched namespace using only Role/RoleBinding RBAC from the Helm chart.
+func TestMlClusterWithEdnode(t *testing.T) {
+	feature := features.New("MarklogicCluster with 2 MarkLogicGroups (dnode + enode)").
+		WithLabel("type", "ednode")
+
+	// Create namespace and admin secret, then deploy the CR.
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: edNodeNS}}
+		if err := client.Resources().Create(ctx, ns); err != nil {
+			t.Fatalf("Failed to create namespace %s: %v", edNodeNS, err)
+		}
+		marklogicv1.AddToScheme(client.Resources(edNodeNS).GetScheme())
+
+		p := e2eutils.RunCommand(fmt.Sprintf(
+			"kubectl -n %s create secret generic %s --from-literal=username=%s --from-literal=password=%s",
+			edNodeNS, edSecretName, adminUsername, adminPassword,
+		))
+		if p.Err() != nil {
+			t.Fatalf("Failed to create admin secret: %s", p.Result())
+		}
+
+		if err := client.Resources(edNodeNS).Create(ctx, edCluster); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(edCluster, func(object k8s.Object) bool {
+				return true
+			}),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("MarklogicCluster CR exists", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var mc marklogicv1.MarklogicCluster
+		if err := client.Resources().Get(ctx, "mlclusterednode", edNodeNS, &mc); err != nil {
+			t.Fatalf("MarklogicCluster not found: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("dnode-0 pod is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "dnode-0", 120*time.Second, true); err != nil {
+			t.Fatalf("dnode-0 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("enode-0 pod is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "enode-0", 180*time.Second, true); err != nil {
+			t.Fatalf("enode-0 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("MarkLogic groups created", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		url := "http://localhost:8002/manage/v2/groups"
+		cmd := fmt.Sprintf("curl %s --anyauth -u %s:%s", url, adminUsername, adminPassword)
+		output, err := utils.ExecCmdInPod("dnode-0", edNodeNS, mlContainerName, cmd)
+		if err != nil {
+			t.Fatalf("Failed to query groups: %v", err)
+		}
+		if !strings.Contains(output, "<nameref>dnode</nameref>") || !strings.Contains(output, "<nameref>enode</nameref>") {
+			t.Logf("Groups output: %s", output)
+			t.Fatal("expected dnode and enode groups in MarkLogic cluster")
+		}
+		return ctx
+	})
+
+	// Scale both groups to 2 replicas.
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var mc marklogicv1.MarklogicCluster
+		if err := client.Resources().Get(ctx, "mlclusterednode", edNodeNS, &mc); err != nil {
+			t.Fatal(err)
+		}
+		mc.Spec.MarkLogicGroups[0].Replicas = &edIncrReplica
+		mc.Spec.MarkLogicGroups[1].Replicas = &edIncrReplica
+		if err := client.Resources().Update(ctx, &mc); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("dnode-1 pod created after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "dnode-1", 60*time.Second, true); err != nil {
+			t.Fatalf("dnode-1 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("enode-1 pod created after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), edNodeNS, "enode-1", 120*time.Second, true); err != nil {
+			t.Fatalf("enode-1 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("4 pods running after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		podList := &corev1.PodList{}
+		if err := client.Resources().List(ctx, podList, func(lo *metav1.ListOptions) {
+			lo.LabelSelector = "app.kubernetes.io/name=marklogic"
+			lo.FieldSelector = "metadata.namespace=" + edNodeNS
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if got := len(podList.Items); got != 4 {
+			t.Fatalf("expected 4 pods after scaling, got %d", got)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(edNodeNS).Delete(ctx, edCluster); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: edNodeNS}}); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", edNodeNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -107,6 +107,10 @@ func TestMlClusterWithEdnode(t *testing.T) {
 		}
 		marklogicv1.AddToScheme(client.Resources(edNodeNS).GetScheme())
 
+		e2eutils.RunCommand(fmt.Sprintf(
+			"kubectl -n %s delete secret %s --ignore-not-found=true",
+			edNodeNS, edSecretName,
+		))
 		p := e2eutils.RunCommand(fmt.Sprintf(
 			"kubectl -n %s create secret generic %s --from-literal=username=%s --from-literal=password=%s",
 			edNodeNS, edSecretName, adminUsername, adminPassword,

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -199,9 +199,8 @@ func TestMlClusterWithEdnode(t *testing.T) {
 	feature.Assess("4 pods running after scaling", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
 		podList := &corev1.PodList{}
-		if err := client.Resources().List(ctx, podList, func(lo *metav1.ListOptions) {
+		if err := client.Resources(edNodeNS).List(ctx, podList, func(lo *metav1.ListOptions) {
 			lo.LabelSelector = "app.kubernetes.io/name=marklogic"
-			lo.FieldSelector = "metadata.namespace=" + edNodeNS
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e-helm/4_ednode_test.go
+++ b/test/e2e-helm/4_ednode_test.go
@@ -12,6 +12,7 @@ import (
 	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
 	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -77,8 +78,31 @@ func TestMlClusterWithEdnode(t *testing.T) {
 	// Create namespace and admin secret, then deploy the CR.
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: edNodeNS}}
-		if err := client.Resources().Create(ctx, ns); err != nil {
+
+		// Wait for any previous terminating namespace to finish before creating a new one.
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, edNodeNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", edNodeNS, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", edNodeNS)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", edNodeNS, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: edNodeNS},
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
 			t.Fatalf("Failed to create namespace %s: %v", edNodeNS, err)
 		}
 		marklogicv1.AddToScheme(client.Resources(edNodeNS).GetScheme())

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -27,6 +27,7 @@ import (
 // TestTlsWithSelfSigned verifies that the operator correctly enables TLS with a
 // self-signed certificate on the default app servers in a watched namespace.
 func TestTlsWithSelfSigned(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Self Signed Certificate").WithLabel("type", "tls-self-signed")
 	tlsNamespace := "ml-ns-tls" // must be in watchedNamespaces
 	releaseName := "ml"
@@ -159,6 +160,7 @@ func TestTlsWithSelfSigned(t *testing.T) {
 // TestTlsWithNamedCert verifies that the operator correctly applies per-pod named
 // TLS certificates in a watched namespace.
 func TestTlsWithNamedCert(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Named Certificate").WithLabel("type", "tls-named-cert")
 	namedNS := "ml-ns-tls-named" // must be in watchedNamespaces
 	releaseName := "marklogic"
@@ -319,6 +321,7 @@ func TestTlsWithNamedCert(t *testing.T) {
 // TestTlsWithMultiNode verifies that TLS with per-pod named certificates works correctly
 // in a two-group (dnode + enode) cluster deployed in a watched namespace.
 func TestTlsWithMultiNode(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Multi Node Named Certificate").WithLabel("type", "tls-multi-node")
 	tlsEdNS := "ml-ns-tls-ednode" // must be in watchedNamespaces
 	enodeName := "enode"

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -1,0 +1,468 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	"github.com/tidwall/gjson"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	e2eutils "sigs.k8s.io/e2e-framework/pkg/utils"
+)
+
+// TestTlsWithSelfSigned verifies that the operator correctly enables TLS with a
+// self-signed certificate on the default app servers in a watched namespace.
+func TestTlsWithSelfSigned(t *testing.T) {
+	feature := features.New("TLS with Self Signed Certificate").WithLabel("type", "tls-self-signed")
+	tlsNamespace := "ml-ns-tls" // must be in watchedNamespaces
+	releaseName := "ml"
+	tlsReplicas := int32(1)
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marklogicclusters",
+			Namespace: tlsNamespace,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        releaseName,
+					Replicas:    &tlsReplicas,
+					IsBootstrap: true,
+				},
+			},
+			Tls: &marklogicv1.Tls{
+				EnableOnDefaultAppServers: true,
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		client.Resources(tlsNamespace).Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: tlsNamespace, Labels: namespaceLabels()},
+		})
+		marklogicv1.AddToScheme(client.Resources(tlsNamespace).GetScheme())
+		if err := client.Resources(tlsNamespace).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), tlsNamespace, "ml-0", 120*time.Second, true); err != nil {
+			t.Fatalf("ml-0 not ready: %v", err)
+		}
+		// Allow time for TLS to be fully configured on management port 8002.
+		t.Log("Waiting for TLS configuration to propagate...")
+		time.Sleep(30 * time.Second)
+
+		httpsCheck := "curl -k -s -o /dev/null -w '%{http_code}' https://localhost:8002/admin/v1/timestamp"
+		var httpsReady bool
+		for i := 0; i < 60; i++ {
+			out, err := utils.ExecCmdInPod("ml-0", tlsNamespace, mlContainerName, httpsCheck)
+			if err == nil && (strings.Contains(out, "200") || strings.Contains(out, "401")) {
+				t.Log("HTTPS is configured and responding")
+				httpsReady = true
+				break
+			}
+			if i == 59 {
+				t.Fatal("HTTPS not configured on port 8002 after 2 minutes")
+			}
+			time.Sleep(2 * time.Second)
+		}
+		if !httpsReady {
+			t.Fatal("HTTPS endpoint never became ready")
+		}
+		return ctx
+	})
+
+	feature.Assess("HTTPS connection enabled on /manage/v2/groups", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cmd := fmt.Sprintf("curl -k --anyauth -u %s:%s https://localhost:8002/manage/v2/groups", adminUsername, adminPassword)
+		if _, err := utils.ExecCmdInPod("ml-0", tlsNamespace, mlContainerName, cmd); err != nil {
+			t.Fatalf("HTTPS request to /manage/v2/groups failed: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("HTTPS connection enabled on /manage/v2/hosts", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cmd := fmt.Sprintf("curl -k --anyauth -u %s:%s https://localhost:8002/manage/v2/hosts?view=status&format=json", adminUsername, adminPassword)
+		if _, err := utils.ExecCmdInPod("ml-0", tlsNamespace, mlContainerName, cmd); err != nil {
+			t.Fatalf("HTTPS request to /manage/v2/hosts failed: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		utils.DeleteNS(ctx, c, tlsNamespace)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestTlsWithNamedCert verifies that the operator correctly applies per-pod named
+// TLS certificates in a watched namespace.
+func TestTlsWithNamedCert(t *testing.T) {
+	feature := features.New("TLS with Named Certificate").WithLabel("type", "tls-named-cert")
+	namedNS := "ml-ns-tls-named" // must be in watchedNamespaces
+	releaseName := "marklogic"
+	namedReplicas := int32(2)
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marklogicclusters",
+			Namespace: namedNS,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        releaseName,
+					Replicas:    &namedReplicas,
+					IsBootstrap: true,
+				},
+			},
+			Tls: &marklogicv1.Tls{
+				EnableOnDefaultAppServers: true,
+				CertSecretNames:           []string{"marklogic-0-cert", "marklogic-1-cert"},
+				CaSecretName:              "ca-cert",
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		client.Resources(namedNS).Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namedNS, Labels: namespaceLabels()},
+		})
+		marklogicv1.AddToScheme(client.Resources(namedNS).GetScheme())
+
+		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {
+			t.Fatalf("Failed to generate CA certificate: %v", err)
+		}
+		if err := utils.GenerateCertificates("test/test_data/pod_zero_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("Failed to generate pod_zero_certs: %v", err)
+		}
+		if err := utils.GenerateCertificates("test/test_data/pod_one_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("Failed to generate pod_one_certs: %v", err)
+		}
+
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret ca-cert --ignore-not-found=true", namedNS))
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret marklogic-0-cert --ignore-not-found=true", namedNS))
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret marklogic-1-cert --ignore-not-found=true", namedNS))
+
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic ca-cert --from-file=test/test_data/ca_cert/cacert.pem", namedNS)); p.Err() != nil {
+			t.Fatalf("Failed to create ca-cert secret: %s", p.Result())
+		}
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-0-cert --from-file=test/test_data/pod_zero_certs/tls.crt --from-file=test/test_data/pod_zero_certs/tls.key", namedNS)); p.Err() != nil {
+			t.Fatalf("Failed to create marklogic-0-cert: %s", p.Result())
+		}
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-1-cert --from-file=test/test_data/pod_one_certs/tls.crt --from-file=test/test_data/pod_one_certs/tls.key", namedNS)); p.Err() != nil {
+			t.Fatalf("Failed to create marklogic-1-cert: %s", p.Result())
+		}
+
+		if err := client.Resources(namedNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("pods marklogic-0 and marklogic-1 are ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), namedNS, "marklogic-0", 180*time.Second, true); err != nil {
+			t.Fatalf("marklogic-0 not ready: %v", err)
+		}
+		if err := utils.WaitForPod(ctx, t, c.Client(), namedNS, "marklogic-1", 180*time.Second, true); err != nil {
+			t.Fatalf("marklogic-1 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Named certificates are applied", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		podName := "marklogic-1"
+		hostnamesSlice := []string{
+			fmt.Sprintf("marklogic-0.marklogic.%s.svc.cluster.local", namedNS),
+			fmt.Sprintf("marklogic-1.marklogic.%s.svc.cluster.local", namedNS),
+		}
+		time.Sleep(5 * time.Second)
+		cmd := fmt.Sprintf("curl -k --anyauth -u %s:%s https://localhost:8002/manage/v2/certificates?format=json", adminUsername, adminPassword)
+		certs, err := utils.ExecCmdInPod(podName, namedNS, mlContainerName, cmd)
+		if err != nil {
+			t.Fatalf("Failed to get certificates list: %v", err)
+		}
+		certURIs := gjson.Get(certs, `certificate-default-list.list-items.list-item.#.uriref`).Array()
+		if len(certURIs) < 2 {
+			t.Fatalf("Expected at least 2 certificates, found %d", len(certURIs))
+		}
+		for i, uri := range certURIs[:2] {
+			certURL := fmt.Sprintf("https://localhost:8002%s?format=json", uri)
+			detail, err := utils.ExecCmdInPod(podName, namedNS, mlContainerName,
+				fmt.Sprintf("curl -k --anyauth -u %s:%s %s", adminUsername, adminPassword, certURL))
+			if err != nil {
+				t.Fatalf("Failed to get certificate %d: %v", i, err)
+			}
+			if gjson.Get(detail, `certificate-default.temporary`).Bool() {
+				t.Fatalf("Certificate %d is still temporary (named cert not applied)", i)
+			}
+			hostname := gjson.Get(detail, `certificate-default.host-name`).String()
+			if !slices.Contains(hostnamesSlice, hostname) {
+				t.Fatalf("Certificate %d hostname %q not in expected list %v", i, hostname, hostnamesSlice)
+			}
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		utils.DeleteNS(ctx, c, namedNS)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestTlsWithMultiNode verifies that TLS with per-pod named certificates works correctly
+// in a two-group (dnode + enode) cluster deployed in a watched namespace.
+func TestTlsWithMultiNode(t *testing.T) {
+	feature := features.New("TLS with Multi Node Named Certificate").WithLabel("type", "tls-multi-node")
+	tlsEdNS := "ml-ns-tls-ednode" // must be in watchedNamespaces
+	enodeName := "enode"
+	dnodeName := "dnode"
+	enodeSize := int32(1)
+	dnodeSize := int32(1)
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marklogicclusters",
+			Namespace: tlsEdNS,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:     dnodeName,
+					Replicas: &dnodeSize,
+					GroupConfig: &marklogicv1.GroupConfig{
+						Name:          dnodeName,
+						EnableXdqpSsl: true,
+					},
+					IsBootstrap: true,
+					Tls: &marklogicv1.Tls{
+						EnableOnDefaultAppServers: true,
+						CertSecretNames:           []string{"dnode-0-cert"},
+						CaSecretName:              "ca-cert",
+					},
+				},
+				{
+					Name:     enodeName,
+					Replicas: &enodeSize,
+					GroupConfig: &marklogicv1.GroupConfig{
+						Name:          enodeName,
+						EnableXdqpSsl: true,
+					},
+					IsBootstrap: false,
+					Tls: &marklogicv1.Tls{
+						EnableOnDefaultAppServers: true,
+						CertSecretNames:           []string{"enode-0-cert"},
+						CaSecretName:              "ca-cert",
+					},
+				},
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+
+		// Wait for any previous terminating namespace to finish.
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, tlsEdNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace status: %v", err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", tlsEdNS)
+				}
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+
+		if err := client.Resources(tlsEdNS).Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: tlsEdNS, Labels: namespaceLabels()},
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", tlsEdNS, err)
+		}
+		marklogicv1.AddToScheme(client.Resources(tlsEdNS).GetScheme())
+
+		if err := client.Resources(tlsEdNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {
+			t.Fatalf("GenerateCACertificate failed: %v", err)
+		}
+		if err := utils.GenerateCertificates("test/test_data/enode_zero_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("GenerateCertificates (enode) failed: %v", err)
+		}
+		if err := utils.GenerateCertificates("test/test_data/dnode_zero_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("GenerateCertificates (dnode) failed: %v", err)
+		}
+
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret ca-cert --ignore-not-found=true", tlsEdNS))
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret dnode-0-cert --ignore-not-found=true", tlsEdNS))
+		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret enode-0-cert --ignore-not-found=true", tlsEdNS))
+
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic ca-cert --from-file=test/test_data/ca_cert/cacert.pem", tlsEdNS)); p.Err() != nil {
+			t.Fatalf("Failed to create ca-cert: %s", p.Result())
+		}
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic dnode-0-cert --from-file=test/test_data/dnode_zero_certs/tls.crt --from-file=test/test_data/dnode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
+			t.Fatalf("Failed to create dnode-0-cert: %s", p.Result())
+		}
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic enode-0-cert --from-file=test/test_data/enode_zero_certs/tls.crt --from-file=test/test_data/enode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
+			t.Fatalf("Failed to create enode-0-cert: %s", p.Result())
+		}
+		return ctx
+	})
+
+	feature.Assess("dnode-0 and enode-0 pods are ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), tlsEdNS, "dnode-0", 180*time.Second, true); err != nil {
+			t.Fatalf("dnode-0 not ready: %v", err)
+		}
+		if err := utils.WaitForPod(ctx, t, c.Client(), tlsEdNS, "enode-0", 180*time.Second, true); err != nil {
+			t.Fatalf("enode-0 not ready: %v", err)
+		}
+		t.Log("Waiting for enode to join cluster and configure TLS...")
+		time.Sleep(60 * time.Second)
+		return ctx
+	})
+
+	feature.Assess("Named certs applied on multi-node cluster", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		podName := "dnode-0"
+		hostnamesSlice := []string{
+			fmt.Sprintf("enode-0.enode.%s.svc.cluster.local", tlsEdNS),
+			fmt.Sprintf("dnode-0.dnode.%s.svc.cluster.local", tlsEdNS),
+		}
+		t.Log("Waiting for TLS configuration on port 8002...")
+		time.Sleep(30 * time.Second)
+
+		httpsCheck := "curl -k -s -o /dev/null -w '%{http_code}' https://localhost:8002/admin/v1/timestamp"
+		for i := 0; i < 60; i++ {
+			out, err := utils.ExecCmdInPod(podName, tlsEdNS, mlContainerName, httpsCheck)
+			if err == nil && (strings.Contains(out, "200") || strings.Contains(out, "401")) {
+				break
+			}
+			if i == 59 {
+				t.Fatal("HTTPS not configured on port 8002 after 2 minutes")
+			}
+			time.Sleep(2 * time.Second)
+		}
+
+		url := "https://localhost:8002/manage/v2/certificates?format=json"
+		cmd := fmt.Sprintf("curl -k --anyauth -u %s:%s %s", adminUsername, adminPassword, url)
+		var certs string
+		var err error
+		for i := 0; i < 10; i++ {
+			certs, err = utils.ExecCmdInPod(podName, tlsEdNS, mlContainerName, cmd)
+			if err == nil {
+				break
+			}
+			time.Sleep(2 * time.Second)
+		}
+		if err != nil {
+			t.Fatalf("Failed to get certificates list: %v", err)
+		}
+		certURIs := gjson.Get(certs, `certificate-default-list.list-items.list-item.#.uriref`).Array()
+		if len(certURIs) < 2 {
+			t.Fatalf("Expected at least 2 certificates, found %d", len(certURIs))
+		}
+		for i, uri := range certURIs[:2] {
+			certURL := fmt.Sprintf("https://localhost:8002%s?format=json", uri)
+			detail, err := utils.ExecCmdInPod(podName, tlsEdNS, mlContainerName,
+				fmt.Sprintf("curl -k --anyauth -u %s:%s %s", adminUsername, adminPassword, certURL))
+			if err != nil {
+				t.Fatalf("Failed to get certificate %d: %v", i, err)
+			}
+			if gjson.Get(detail, `certificate-default.temporary`).Bool() {
+				t.Fatalf("Certificate %d is still temporary", i)
+			}
+			hostname := gjson.Get(detail, `certificate-default.host-name`).String()
+			if !slices.Contains(hostnamesSlice, hostname) {
+				t.Fatalf("Certificate %d hostname %q not in expected list %v", i, hostname, hostnamesSlice)
+			}
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		utils.DeleteNS(ctx, c, tlsEdNS)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -105,6 +105,7 @@ func TestTlsWithSelfSigned(t *testing.T) {
 
 	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), tlsNamespace, "ml-0", 120*time.Second, true); err != nil {
+			logDiagnostics(t, tlsNamespace)
 			t.Fatalf("ml-0 not ready: %v", err)
 		}
 		// Allow time for TLS to be fully configured on management port 8002.
@@ -263,9 +264,11 @@ func TestTlsWithNamedCert(t *testing.T) {
 
 	feature.Assess("pods marklogic-0 and marklogic-1 are ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), namedNS, "marklogic-0", 180*time.Second, true); err != nil {
+			logDiagnostics(t, namedNS)
 			t.Fatalf("marklogic-0 not ready: %v", err)
 		}
 		if err := utils.WaitForPod(ctx, t, c.Client(), namedNS, "marklogic-1", 180*time.Second, true); err != nil {
+			logDiagnostics(t, namedNS)
 			t.Fatalf("marklogic-1 not ready: %v", err)
 		}
 		return ctx
@@ -442,9 +445,11 @@ func TestTlsWithMultiNode(t *testing.T) {
 
 	feature.Assess("dnode-0 and enode-0 pods are ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), tlsEdNS, "dnode-0", 180*time.Second, true); err != nil {
+			logDiagnostics(t, tlsEdNS)
 			t.Fatalf("dnode-0 not ready: %v", err)
 		}
 		if err := utils.WaitForPod(ctx, t, c.Client(), tlsEdNS, "enode-0", 180*time.Second, true); err != nil {
+			logDiagnostics(t, tlsEdNS)
 			t.Fatalf("enode-0 not ready: %v", err)
 		}
 		t.Log("Waiting for enode to join cluster and configure TLS...")

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -401,17 +401,8 @@ func TestTlsWithMultiNode(t *testing.T) {
 		}
 		marklogicv1.AddToScheme(client.Resources(tlsEdNS).GetScheme())
 
-		if err := client.Resources(tlsEdNS).Create(ctx, cr); err != nil {
-			t.Fatalf("Failed to create MarklogicCluster: %v", err)
-		}
-		if err := wait.For(
-			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
-			wait.WithTimeout(3*time.Minute),
-			wait.WithInterval(5*time.Second),
-		); err != nil {
-			t.Fatal(err)
-		}
-
+		// Generate and populate TLS secrets before creating the CR so the operator
+		// never reconciles against missing secrets.
 		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {
 			t.Fatalf("GenerateCACertificate failed: %v", err)
 		}
@@ -434,6 +425,17 @@ func TestTlsWithMultiNode(t *testing.T) {
 		}
 		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic enode-0-cert --from-file=test/test_data/enode_zero_certs/tls.crt --from-file=test/test_data/enode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
 			t.Fatalf("Failed to create enode-0-cert: %s", p.Result())
+		}
+
+		if err := client.Resources(tlsEdNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
 		}
 		return ctx
 	})

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -228,11 +228,11 @@ func TestTlsWithNamedCert(t *testing.T) {
 		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {
 			t.Fatalf("Failed to generate CA certificate: %v", err)
 		}
-		if err := utils.GenerateCertificates("test/test_data/pod_zero_certs", "test/test_data/ca_cert"); err != nil {
-			t.Fatalf("Failed to generate pod_zero_certs: %v", err)
+		if err := utils.GenerateCertificates("test/test_data/helm_pod_zero_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("Failed to generate helm_pod_zero_certs: %v", err)
 		}
-		if err := utils.GenerateCertificates("test/test_data/pod_one_certs", "test/test_data/ca_cert"); err != nil {
-			t.Fatalf("Failed to generate pod_one_certs: %v", err)
+		if err := utils.GenerateCertificates("test/test_data/helm_pod_one_certs", "test/test_data/ca_cert"); err != nil {
+			t.Fatalf("Failed to generate helm_pod_one_certs: %v", err)
 		}
 
 		e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s delete secret ca-cert --ignore-not-found=true", namedNS))
@@ -242,10 +242,10 @@ func TestTlsWithNamedCert(t *testing.T) {
 		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic ca-cert --from-file=test/test_data/ca_cert/cacert.pem", namedNS)); p.Err() != nil {
 			t.Fatalf("Failed to create ca-cert secret: %s", p.Result())
 		}
-		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-0-cert --from-file=test/test_data/pod_zero_certs/tls.crt --from-file=test/test_data/pod_zero_certs/tls.key", namedNS)); p.Err() != nil {
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-0-cert --from-file=test/test_data/helm_pod_zero_certs/tls.crt --from-file=test/test_data/helm_pod_zero_certs/tls.key", namedNS)); p.Err() != nil {
 			t.Fatalf("Failed to create marklogic-0-cert: %s", p.Result())
 		}
-		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-1-cert --from-file=test/test_data/pod_one_certs/tls.crt --from-file=test/test_data/pod_one_certs/tls.key", namedNS)); p.Err() != nil {
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic marklogic-1-cert --from-file=test/test_data/helm_pod_one_certs/tls.crt --from-file=test/test_data/helm_pod_one_certs/tls.key", namedNS)); p.Err() != nil {
 			t.Fatalf("Failed to create marklogic-1-cert: %s", p.Result())
 		}
 
@@ -409,10 +409,10 @@ func TestTlsWithMultiNode(t *testing.T) {
 		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {
 			t.Fatalf("GenerateCACertificate failed: %v", err)
 		}
-		if err := utils.GenerateCertificates("test/test_data/enode_zero_certs", "test/test_data/ca_cert"); err != nil {
+		if err := utils.GenerateCertificates("test/test_data/helm_enode_zero_certs", "test/test_data/ca_cert"); err != nil {
 			t.Fatalf("GenerateCertificates (enode) failed: %v", err)
 		}
-		if err := utils.GenerateCertificates("test/test_data/dnode_zero_certs", "test/test_data/ca_cert"); err != nil {
+		if err := utils.GenerateCertificates("test/test_data/helm_dnode_zero_certs", "test/test_data/ca_cert"); err != nil {
 			t.Fatalf("GenerateCertificates (dnode) failed: %v", err)
 		}
 
@@ -423,10 +423,10 @@ func TestTlsWithMultiNode(t *testing.T) {
 		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic ca-cert --from-file=test/test_data/ca_cert/cacert.pem", tlsEdNS)); p.Err() != nil {
 			t.Fatalf("Failed to create ca-cert: %s", p.Result())
 		}
-		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic dnode-0-cert --from-file=test/test_data/dnode_zero_certs/tls.crt --from-file=test/test_data/dnode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic dnode-0-cert --from-file=test/test_data/helm_dnode_zero_certs/tls.crt --from-file=test/test_data/helm_dnode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
 			t.Fatalf("Failed to create dnode-0-cert: %s", p.Result())
 		}
-		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic enode-0-cert --from-file=test/test_data/enode_zero_certs/tls.crt --from-file=test/test_data/enode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
+		if p := e2eutils.RunCommand(fmt.Sprintf("kubectl -n %s create secret generic enode-0-cert --from-file=test/test_data/helm_enode_zero_certs/tls.crt --from-file=test/test_data/helm_enode_zero_certs/tls.key", tlsEdNS)); p.Err() != nil {
 			t.Fatalf("Failed to create enode-0-cert: %s", p.Result())
 		}
 

--- a/test/e2e-helm/5_tls_test.go
+++ b/test/e2e-helm/5_tls_test.go
@@ -62,9 +62,33 @@ func TestTlsWithSelfSigned(t *testing.T) {
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		client.Resources(tlsNamespace).Create(ctx, &corev1.Namespace{
+
+		// Wait for any previous terminating namespace to finish before creating a new one.
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, tlsNamespace, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", tlsNamespace, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", tlsNamespace)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", tlsNamespace, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: tlsNamespace, Labels: namespaceLabels()},
-		})
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", tlsNamespace, err)
+		}
 		marklogicv1.AddToScheme(client.Resources(tlsNamespace).GetScheme())
 		if err := client.Resources(tlsNamespace).Create(ctx, cr); err != nil {
 			t.Fatalf("Failed to create MarklogicCluster: %v", err)
@@ -171,9 +195,33 @@ func TestTlsWithNamedCert(t *testing.T) {
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		client.Resources(namedNS).Create(ctx, &corev1.Namespace{
+
+		// Wait for any previous terminating namespace to finish before creating a new one.
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, namedNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", namedNS, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", namedNS)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", namedNS, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: namedNS, Labels: namespaceLabels()},
-		})
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", namedNS, err)
+		}
 		marklogicv1.AddToScheme(client.Resources(namedNS).GetScheme())
 
 		if err := utils.GenerateCACertificate("test/test_data/ca_cert"); err != nil {

--- a/test/e2e-helm/6_haproxy_test.go
+++ b/test/e2e-helm/6_haproxy_test.go
@@ -24,6 +24,7 @@ import (
 // TestHAProxyPathBasedEnabled verifies that path-based HAProxy routing works correctly
 // in a watched namespace with namespace-scoped RBAC.
 func TestHAProxyPathBasedEnabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("HAProxy with Path-Based Routing Enabled").WithLabel("type", "haproxy-pathbased-enabled")
 	haProxyPathNS := "ml-ns-haproxy-path" // must be in watchedNamespaces
 	releaseName := "ml"
@@ -149,6 +150,7 @@ func TestHAProxyPathBasedEnabled(t *testing.T) {
 // TestHAProxyPathBasedDisabled verifies that HAProxy with path-based routing disabled
 // works correctly in a watched namespace.
 func TestHAProxyPathBasedDisabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("HAProxy with Path-Based Routing Disabled").WithLabel("type", "haproxy-pathbased-disabled")
 	haProxyNS := "ml-ns-haproxy" // must be in watchedNamespaces
 	releaseName := "ml"

--- a/test/e2e-helm/6_haproxy_test.go
+++ b/test/e2e-helm/6_haproxy_test.go
@@ -107,6 +107,7 @@ func TestHAProxyPathBasedEnabled(t *testing.T) {
 
 	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), haProxyPathNS, "ml-0", 120*time.Second, true); err != nil {
+			logDiagnostics(t, haProxyPathNS)
 			t.Fatalf("ml-0 not ready: %v", err)
 		}
 		return ctx
@@ -231,6 +232,7 @@ func TestHAProxyPathBasedDisabled(t *testing.T) {
 
 	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), haProxyNS, "ml-0", 120*time.Second, true); err != nil {
+			logDiagnostics(t, haProxyNS)
 			t.Fatalf("ml-0 not ready: %v", err)
 		}
 		return ctx

--- a/test/e2e-helm/6_haproxy_test.go
+++ b/test/e2e-helm/6_haproxy_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// TestHAProxyPathBasedEnabled verifies that path-based HAProxy routing works correctly
+// in a watched namespace with namespace-scoped RBAC.
+func TestHAProxyPathBasedEnabled(t *testing.T) {
+	feature := features.New("HAProxy with Path-Based Routing Enabled").WithLabel("type", "haproxy-pathbased-enabled")
+	haProxyPathNS := "ml-ns-haproxy-path" // must be in watchedNamespaces
+	releaseName := "ml"
+	haReplicas := int32(1)
+	trueVal := true
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marklogicclusters",
+			Namespace: haProxyPathNS,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        releaseName,
+					Replicas:    &haReplicas,
+					IsBootstrap: true,
+				},
+			},
+			HAProxy: &marklogicv1.HAProxy{
+				Enabled:          true,
+				PathBasedRouting: &trueVal,
+				FrontendPort:     8080,
+				AppServers: []marklogicv1.AppServers{
+					{Name: "app-service", Port: 8000, Path: "/console"},
+					{Name: "admin", Port: 8001, Path: "/adminUI"},
+					{Name: "manage", Port: 8002, Path: "/manage"},
+				},
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		client.Resources(haProxyPathNS).Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: haProxyPathNS, Labels: namespaceLabels()},
+		})
+		marklogicv1.AddToScheme(client.Resources(haProxyPathNS).GetScheme())
+		if err := client.Resources(haProxyPathNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), haProxyPathNS, "ml-0", 120*time.Second, true); err != nil {
+			t.Fatalf("ml-0 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("HAProxy with path-based routing is working", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		fqdn := fmt.Sprintf("marklogic-haproxy.%s.svc.cluster.local", haProxyPathNS)
+		url := "http://" + fqdn + ":8080/adminUI"
+		cmd := fmt.Sprintf("curl --anyauth -u %s:%s %s", adminUsername, adminPassword, url)
+		time.Sleep(5 * time.Second)
+		if _, err := utils.ExecCmdInPod("ml-0", haProxyPathNS, mlContainerName, cmd); err != nil {
+			t.Fatalf("HAProxy path-based routing check failed: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("HAProxy with path-based routing sets authentication to BASIC", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		fqdn := fmt.Sprintf("ml-0.ml.%s.svc.cluster.local", haProxyPathNS)
+		url := "http://" + fqdn + ":8001"
+		cmd := fmt.Sprintf("curl -I %s", url)
+		res, err := utils.ExecCmdInPod("ml-0", haProxyPathNS, mlContainerName, cmd)
+		if err != nil {
+			t.Fatalf("Failed to check authentication method: %v", err)
+		}
+		if !strings.Contains(res, "WWW-Authenticate: Basic") {
+			t.Fatalf("Expected Basic auth header, got: %s", res)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		utils.DeleteNS(ctx, c, haProxyPathNS)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestHAProxyPathBasedDisabled verifies that HAProxy with path-based routing disabled
+// works correctly in a watched namespace.
+func TestHAProxyPathBasedDisabled(t *testing.T) {
+	feature := features.New("HAProxy with Path-Based Routing Disabled").WithLabel("type", "haproxy-pathbased-disabled")
+	haProxyNS := "ml-ns-haproxy" // must be in watchedNamespaces
+	releaseName := "ml"
+	haReplicas := int32(1)
+	falseVal := false
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marklogicclusters",
+			Namespace: haProxyNS,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        releaseName,
+					Replicas:    &haReplicas,
+					IsBootstrap: true,
+				},
+			},
+			HAProxy: &marklogicv1.HAProxy{
+				Enabled:          true,
+				PathBasedRouting: &falseVal,
+				FrontendPort:     8090,
+				AppServers: []marklogicv1.AppServers{
+					{Name: "app-service", Port: 8000, Path: "/console"},
+					{Name: "admin", Port: 8001, Path: "/adminUI"},
+					{Name: "manage", Port: 8002, Path: "/manage"},
+				},
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		client.Resources(haProxyNS).Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: haProxyNS, Labels: namespaceLabels()},
+		})
+		marklogicv1.AddToScheme(client.Resources(haProxyNS).GetScheme())
+		if err := client.Resources(haProxyNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("pod ml-0 is ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), haProxyNS, "ml-0", 120*time.Second, true); err != nil {
+			t.Fatalf("ml-0 not ready: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("HAProxy with path-based routing disabled is working", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		fqdn := fmt.Sprintf("marklogic-haproxy.%s.svc.cluster.local", haProxyNS)
+		url := "http://" + fqdn + ":8001"
+		cmd := fmt.Sprintf("curl --anyauth -u %s:%s %s", adminUsername, adminPassword, url)
+		time.Sleep(5 * time.Second)
+		if _, err := utils.ExecCmdInPod("ml-0", haProxyNS, mlContainerName, cmd); err != nil {
+			t.Fatalf("HAProxy request failed: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("HAProxy with path-based routing disabled keeps Digest authentication", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		fqdn := fmt.Sprintf("ml-0.ml.%s.svc.cluster.local", haProxyNS)
+		url := "http://" + fqdn + ":8001"
+		cmd := fmt.Sprintf("curl -I %s", url)
+		res, err := utils.ExecCmdInPod("ml-0", haProxyNS, mlContainerName, cmd)
+		if err != nil {
+			t.Fatalf("Failed to check authentication method: %v", err)
+		}
+		if !strings.Contains(res, "WWW-Authenticate: Digest") {
+			t.Fatalf("Expected Digest auth header, got: %s", res)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		utils.DeleteNS(ctx, c, haProxyNS)
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/6_haproxy_test.go
+++ b/test/e2e-helm/6_haproxy_test.go
@@ -12,6 +12,7 @@ import (
 	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
 	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -66,9 +67,30 @@ func TestHAProxyPathBasedEnabled(t *testing.T) {
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		client.Resources(haProxyPathNS).Create(ctx, &corev1.Namespace{
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, haProxyPathNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", haProxyPathNS, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", haProxyPathNS)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", haProxyPathNS, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: haProxyPathNS, Labels: namespaceLabels()},
-		})
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", haProxyPathNS, err)
+		}
 		marklogicv1.AddToScheme(client.Resources(haProxyPathNS).GetScheme())
 		if err := client.Resources(haProxyPathNS).Create(ctx, cr); err != nil {
 			t.Fatalf("Failed to create MarklogicCluster: %v", err)
@@ -169,9 +191,30 @@ func TestHAProxyPathBasedDisabled(t *testing.T) {
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
-		client.Resources(haProxyNS).Create(ctx, &corev1.Namespace{
+		ns := &corev1.Namespace{}
+		for i := 0; i < 60; i++ {
+			err := client.Resources().Get(ctx, haProxyNS, "", ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					break
+				}
+				t.Fatalf("Error checking namespace %s: %v", haProxyNS, err)
+			}
+			if ns.Status.Phase == corev1.NamespaceTerminating {
+				if i == 59 {
+					t.Fatalf("Timeout waiting for namespace %s to finish terminating", haProxyNS)
+				}
+				t.Logf("Namespace %s is terminating, waiting... (%d/60)", haProxyNS, i+1)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+		if err := client.Resources().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: haProxyNS, Labels: namespaceLabels()},
-		})
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("Failed to create namespace %s: %v", haProxyNS, err)
+		}
 		marklogicv1.AddToScheme(client.Resources(haProxyNS).GetScheme())
 		if err := client.Resources(haProxyNS).Create(ctx, cr); err != nil {
 			t.Fatalf("Failed to create MarklogicCluster: %v", err)

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -4,6 +4,7 @@ package e2ehelm
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+	e2eutils "sigs.k8s.io/e2e-framework/pkg/utils"
 )
 
 const (
@@ -25,29 +27,32 @@ const (
 	logGroupName = "lognode"
 )
 
-// deleteAndRecreateLogNS deletes the log namespace (if it exists) and waits for full
-// removal before returning. This keeps each log-collection test starting from a clean state.
-func deleteAndRecreateLogNS(ctx context.Context, t *testing.T, c *envconf.Config) {
+// cleanupLogNS deletes all MarklogicCluster CRs in logNS and waits for the
+// operator to remove their StatefulSets. The namespace itself (and the
+// Helm-installed Role/RoleBinding) is intentionally preserved so the operator
+// retains RBAC for subsequent tests. Deleting and recreating the namespace
+// would destroy the Helm-created RBAC, leaving the operator forbidden from
+// creating resources in the fresh namespace.
+func cleanupLogNS(ctx context.Context, t *testing.T, _ *envconf.Config) {
 	t.Helper()
-	client := c.Client()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}
-	if err := client.Resources().Get(ctx, logNS, "", ns); err == nil {
-		if err := client.Resources().Delete(ctx, ns); err != nil {
-			t.Logf("Warning: failed to delete existing namespace %s: %v", logNS, err)
-		}
-		if err := wait.For(
-			conditions.New(client.Resources()).ResourceDeleted(ns),
-			wait.WithTimeout(2*time.Minute),
-			wait.WithInterval(2*time.Second),
-		); err != nil {
-			t.Fatalf("Timed out waiting for namespace %s to be deleted before recreation: %v", logNS, err)
-		}
+	// Delete all MarklogicCluster CRs in the namespace.
+	if p := e2eutils.RunCommand(fmt.Sprintf(
+		"kubectl delete marklogicclusters --all -n %s --ignore-not-found=true", logNS,
+	)); p.Err() != nil {
+		t.Logf("Warning: could not delete MarklogicCluster CRs in %s: %s", logNS, p.Result())
 	}
-	if err := client.Resources().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: logNS, Labels: namespaceLabels()},
-	}); err != nil {
-		t.Fatalf("Failed to create namespace %s: %v", logNS, err)
+	// Wait for the operator to cascade-delete all StatefulSets.
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		p := e2eutils.RunCommand(fmt.Sprintf(
+			"kubectl get statefulsets -n %s -o name 2>/dev/null", logNS,
+		))
+		if strings.TrimSpace(p.Result()) == "" {
+			return
+		}
+		time.Sleep(3 * time.Second)
 	}
+	t.Logf("Warning: StatefulSets in %s may not be fully cleaned up before next test", logNS)
 }
 
 // TestLogCollectionDisabled verifies that fluent-bit is NOT created when
@@ -69,7 +74,7 @@ func TestLogCollectionDisabled(t *testing.T) {
 	}
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		deleteAndRecreateLogNS(ctx, t, c)
+		cleanupLogNS(ctx, t, c)
 		client := c.Client()
 		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
 		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
@@ -116,12 +121,8 @@ func TestLogCollectionDisabled(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client := c.Client()
-		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+		if err := c.Client().Resources(logNS).Delete(ctx, cr); err != nil {
 			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
-		}
-		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
-			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
 		}
 		return ctx
 	})
@@ -159,7 +160,7 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 	}
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		deleteAndRecreateLogNS(ctx, t, c)
+		cleanupLogNS(ctx, t, c)
 		client := c.Client()
 		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
 		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
@@ -212,12 +213,8 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client := c.Client()
-		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+		if err := c.Client().Resources(logNS).Delete(ctx, cr); err != nil {
 			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
-		}
-		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
-			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
 		}
 		return ctx
 	})
@@ -261,7 +258,7 @@ func TestLogCollectionCustomResources(t *testing.T) {
 	}
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		deleteAndRecreateLogNS(ctx, t, c)
+		cleanupLogNS(ctx, t, c)
 		client := c.Client()
 		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
 		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
@@ -315,12 +312,8 @@ func TestLogCollectionCustomResources(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client := c.Client()
-		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+		if err := c.Client().Resources(logNS).Delete(ctx, cr); err != nil {
 			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
-		}
-		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
-			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
 		}
 		return ctx
 	})
@@ -361,7 +354,7 @@ func TestLogCollectionCustomFilters(t *testing.T) {
 	}
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		deleteAndRecreateLogNS(ctx, t, c)
+		cleanupLogNS(ctx, t, c)
 		client := c.Client()
 		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
 		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
@@ -402,12 +395,8 @@ func TestLogCollectionCustomFilters(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client := c.Client()
-		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+		if err := c.Client().Resources(logNS).Delete(ctx, cr); err != nil {
 			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
-		}
-		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
-			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
 		}
 		return ctx
 	})

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -40,7 +40,7 @@ func deleteAndRecreateLogNS(ctx context.Context, t *testing.T, c *envconf.Config
 			wait.WithTimeout(2*time.Minute),
 			wait.WithInterval(2*time.Second),
 		); err != nil {
-			t.Logf("Warning: namespace deletion timeout, proceeding: %v", err)
+			t.Fatalf("Timed out waiting for namespace %s to be deleted before recreation: %v", logNS, err)
 		}
 	}
 	if err := client.Resources().Create(ctx, &corev1.Namespace{

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -55,18 +55,14 @@ func deleteAndRecreateLogNS(ctx context.Context, t *testing.T, c *envconf.Config
 func TestLogCollectionDisabled(t *testing.T) {
 	feature := features.New("Log Collection Disabled").WithLabel("type", "log-collection-disabled")
 
-	adminUser := "admin"
-	adminPass := "Admin@8001"
-	r := int32(1)
-
 	cr := &marklogicv1.MarklogicCluster{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
 		ObjectMeta: metav1.ObjectMeta{Name: "ml-no-logs", Namespace: logNS},
 		Spec: marklogicv1.MarklogicClusterSpec{
 			Image: marklogicImage,
-			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUsername, AdminPassword: &adminPassword},
 			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
-				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+				{Name: logGroupName, Replicas: &replicas, IsBootstrap: true},
 			},
 			LogCollection: &marklogicv1.LogCollection{Enabled: false},
 		},
@@ -136,18 +132,14 @@ func TestLogCollectionDisabled(t *testing.T) {
 func TestLogCollectionPartialLogs(t *testing.T) {
 	feature := features.New("Log Collection Partial Logs").WithLabel("type", "log-collection-partial")
 
-	adminUser := "admin"
-	adminPass := "Admin@8001"
-	r := int32(1)
-
 	cr := &marklogicv1.MarklogicCluster{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
 		ObjectMeta: metav1.ObjectMeta{Name: "ml-partial-logs", Namespace: logNS},
 		Spec: marklogicv1.MarklogicClusterSpec{
 			Image: marklogicImage,
-			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUsername, AdminPassword: &adminPassword},
 			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
-				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+				{Name: logGroupName, Replicas: &replicas, IsBootstrap: true},
 			},
 			LogCollection: &marklogicv1.LogCollection{
 				Enabled: true,
@@ -234,10 +226,6 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 func TestLogCollectionCustomResources(t *testing.T) {
 	feature := features.New("Log Collection Custom Resources").WithLabel("type", "log-collection-resources")
 
-	adminUser := "admin"
-	adminPass := "Admin@8001"
-	r := int32(1)
-
 	customRes := &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -254,9 +242,9 @@ func TestLogCollectionCustomResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "ml-custom-resources", Namespace: logNS},
 		Spec: marklogicv1.MarklogicClusterSpec{
 			Image: marklogicImage,
-			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUsername, AdminPassword: &adminPassword},
 			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
-				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+				{Name: logGroupName, Replicas: &replicas, IsBootstrap: true},
 			},
 			LogCollection: &marklogicv1.LogCollection{
 				Enabled:   true,
@@ -339,10 +327,6 @@ func TestLogCollectionCustomResources(t *testing.T) {
 func TestLogCollectionCustomFilters(t *testing.T) {
 	feature := features.New("Log Collection Custom Filters").WithLabel("type", "log-collection-filters")
 
-	adminUser := "admin"
-	adminPass := "Admin@8001"
-	r := int32(1)
-
 	customFilters := `- name: grep
   match: "*"
   regex: log ERROR
@@ -356,9 +340,9 @@ func TestLogCollectionCustomFilters(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "ml-custom-filters", Namespace: logNS},
 		Spec: marklogicv1.MarklogicClusterSpec{
 			Image: marklogicImage,
-			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUsername, AdminPassword: &adminPassword},
 			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
-				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+				{Name: logGroupName, Replicas: &replicas, IsBootstrap: true},
 			},
 			LogCollection: &marklogicv1.LogCollection{
 				Enabled: true,

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -1,0 +1,424 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	logNS        = "ml-ns-log" // must be in watchedNamespaces
+	logGroupName = "lognode"
+)
+
+// deleteAndRecreateLogNS deletes the log namespace (if it exists) and waits for full
+// removal before returning. This keeps each log-collection test starting from a clean state.
+func deleteAndRecreateLogNS(ctx context.Context, t *testing.T, c *envconf.Config) {
+	t.Helper()
+	client := c.Client()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}
+	if err := client.Resources().Get(ctx, logNS, "", ns); err == nil {
+		if err := client.Resources().Delete(ctx, ns); err != nil {
+			t.Logf("Warning: failed to delete existing namespace %s: %v", logNS, err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceDeleted(ns),
+			wait.WithTimeout(2*time.Minute),
+			wait.WithInterval(2*time.Second),
+		); err != nil {
+			t.Logf("Warning: namespace deletion timeout, proceeding: %v", err)
+		}
+	}
+	if err := client.Resources().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: logNS, Labels: namespaceLabels()},
+	}); err != nil {
+		t.Fatalf("Failed to create namespace %s: %v", logNS, err)
+	}
+}
+
+// TestLogCollectionDisabled verifies that fluent-bit is NOT created when
+// LogCollection.Enabled is false.
+func TestLogCollectionDisabled(t *testing.T) {
+	feature := features.New("Log Collection Disabled").WithLabel("type", "log-collection-disabled")
+
+	adminUser := "admin"
+	adminPass := "Admin@8001"
+	r := int32(1)
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ml-no-logs", Namespace: logNS},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+			},
+			LogCollection: &marklogicv1.LogCollection{Enabled: false},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		deleteAndRecreateLogNS(ctx, t, c)
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
+		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Pod created without fluent-bit container", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := utils.WaitForPod(ctx, t, client, logNS, "lognode-0", 120*time.Second); err != nil {
+			t.Fatalf("Failed to wait for pod: %v", err)
+		}
+		var pod corev1.Pod
+		if err := client.Resources().Get(ctx, "lognode-0", logNS, &pod); err != nil {
+			t.Fatalf("Failed to get pod: %v", err)
+		}
+		if len(pod.Spec.Containers) != 1 {
+			t.Fatalf("Expected 1 container when log collection disabled, found %d", len(pod.Spec.Containers))
+		}
+		if pod.Spec.Containers[0].Name != "marklogic-server" {
+			t.Fatalf("Expected only marklogic-server container, got %s", pod.Spec.Containers[0].Name)
+		}
+		t.Log("Verified: fluent-bit container is NOT present when LogCollection is disabled")
+		return ctx
+	})
+
+	feature.Assess("Fluent-bit ConfigMap not created", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		var cm corev1.ConfigMap
+		if err := c.Client().Resources().Get(ctx, "fluent-bit", logNS, &cm); err == nil {
+			t.Fatal("fluent-bit ConfigMap should not exist when LogCollection is disabled")
+		}
+		t.Log("Verified: fluent-bit ConfigMap is NOT created when LogCollection is disabled")
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestLogCollectionPartialLogs verifies that only the requested log files are configured
+// in the fluent-bit ConfigMap.
+func TestLogCollectionPartialLogs(t *testing.T) {
+	feature := features.New("Log Collection Partial Logs").WithLabel("type", "log-collection-partial")
+
+	adminUser := "admin"
+	adminPass := "Admin@8001"
+	r := int32(1)
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ml-partial-logs", Namespace: logNS},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+			},
+			LogCollection: &marklogicv1.LogCollection{
+				Enabled: true,
+				Image:   "fluent/fluent-bit:4.1.1",
+				Files: marklogicv1.LogFilesConfig{
+					ErrorLogs:   true,
+					AccessLogs:  false,
+					RequestLogs: false,
+					CrashLogs:   false,
+					AuditLogs:   false,
+				},
+				Outputs: "[OUTPUT]\n\tname stdout\n\tmatch *\n\tformat json_lines",
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		deleteAndRecreateLogNS(ctx, t, c)
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
+		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Pod created with fluent-bit container", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := utils.WaitForPod(ctx, t, client, logNS, "lognode-0", 120*time.Second); err != nil {
+			t.Fatalf("Failed to wait for pod: %v", err)
+		}
+		var pod corev1.Pod
+		if err := client.Resources().Get(ctx, "lognode-0", logNS, &pod); err != nil {
+			t.Fatalf("Failed to get pod: %v", err)
+		}
+		if len(pod.Spec.Containers) != 2 {
+			t.Fatalf("Expected 2 containers (marklogic-server + fluent-bit), found %d", len(pod.Spec.Containers))
+		}
+		t.Log("Verified: pod has fluent-bit container for partial log collection")
+		return ctx
+	})
+
+	feature.Assess("Fluent-bit ConfigMap has only error logs", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		var cm corev1.ConfigMap
+		if err := c.Client().Resources().Get(ctx, "fluent-bit", logNS, &cm); err != nil {
+			t.Fatalf("Failed to get fluent-bit ConfigMap: %v", err)
+		}
+		cfg := cm.Data["fluent-bit.yaml"]
+		if !strings.Contains(cfg, "ErrorLog.txt") {
+			t.Fatal("ErrorLog.txt should be present in configuration")
+		}
+		for _, unexpected := range []string{"AccessLog.txt", "RequestLog.txt", "CrashLog.txt", "AuditLog.txt"} {
+			if strings.Contains(cfg, unexpected) {
+				t.Fatalf("%s should not be present when disabled", unexpected)
+			}
+		}
+		t.Log("Verified: only error logs are configured in fluent-bit")
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestLogCollectionCustomResources verifies that custom resource requests/limits for the
+// fluent-bit sidecar are applied correctly.
+func TestLogCollectionCustomResources(t *testing.T) {
+	feature := features.New("Log Collection Custom Resources").WithLabel("type", "log-collection-resources")
+
+	adminUser := "admin"
+	adminPass := "Admin@8001"
+	r := int32(1)
+
+	customRes := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("150m"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
+		},
+	}
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ml-custom-resources", Namespace: logNS},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+			},
+			LogCollection: &marklogicv1.LogCollection{
+				Enabled:   true,
+				Image:     "fluent/fluent-bit:4.1.1",
+				Resources: customRes,
+				Files:     marklogicv1.LogFilesConfig{ErrorLogs: true},
+				Outputs:   "[OUTPUT]\n\tname stdout\n\tmatch *",
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		deleteAndRecreateLogNS(ctx, t, c)
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
+		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Pod created with custom resources", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), logNS, "lognode-0", 120*time.Second); err != nil {
+			t.Fatalf("Failed to wait for pod: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Custom resources are applied to fluent-bit container", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		var pod corev1.Pod
+		if err := c.Client().Resources().Get(ctx, "lognode-0", logNS, &pod); err != nil {
+			t.Fatalf("Failed to get pod: %v", err)
+		}
+		var fb *corev1.Container
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name == "fluent-bit" {
+				fb = &pod.Spec.Containers[i]
+				break
+			}
+		}
+		if fb == nil {
+			t.Fatal("fluent-bit container not found in pod")
+		}
+		checkResource := func(name string, got, want resource.Quantity) {
+			if got.Cmp(want) != 0 {
+				t.Fatalf("fluent-bit %s: expected %v, got %v", name, want, got)
+			}
+		}
+		checkResource("CPU request", fb.Resources.Requests[corev1.ResourceCPU], resource.MustParse("50m"))
+		checkResource("Memory request", fb.Resources.Requests[corev1.ResourceMemory], resource.MustParse("100Mi"))
+		checkResource("CPU limit", fb.Resources.Limits[corev1.ResourceCPU], resource.MustParse("150m"))
+		checkResource("Memory limit", fb.Resources.Limits[corev1.ResourceMemory], resource.MustParse("300Mi"))
+		t.Log("Verified: custom resources are correctly applied to fluent-bit container")
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestLogCollectionCustomFilters verifies that custom fluent-bit filter configuration
+// is correctly written to the fluent-bit ConfigMap.
+func TestLogCollectionCustomFilters(t *testing.T) {
+	feature := features.New("Log Collection Custom Filters").WithLabel("type", "log-collection-filters")
+
+	adminUser := "admin"
+	adminPass := "Admin@8001"
+	r := int32(1)
+
+	customFilters := `- name: grep
+  match: "*"
+  regex: log ERROR
+- name: modify
+  match: "*"
+  add:
+    - custom_field custom_value`
+
+	cr := &marklogicv1.MarklogicCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ml-custom-filters", Namespace: logNS},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth:  &marklogicv1.AdminAuth{AdminUsername: &adminUser, AdminPassword: &adminPass},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{Name: logGroupName, Replicas: &r, IsBootstrap: true},
+			},
+			LogCollection: &marklogicv1.LogCollection{
+				Enabled: true,
+				Image:   "fluent/fluent-bit:4.1.1",
+				Files:   marklogicv1.LogFilesConfig{ErrorLogs: true},
+				Filters: customFilters,
+				Outputs: "[OUTPUT]\n\tname stdout\n\tmatch *",
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		deleteAndRecreateLogNS(ctx, t, c)
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources(logNS).GetScheme())
+		if err := client.Resources(logNS).Create(ctx, cr); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %v", err)
+		}
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(cr, func(object k8s.Object) bool { return true }),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Pod created with custom filters", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := utils.WaitForPod(ctx, t, c.Client(), logNS, "lognode-0", 120*time.Second); err != nil {
+			t.Fatalf("Failed to wait for pod: %v", err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Custom filters are in fluent-bit ConfigMap", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		var cm corev1.ConfigMap
+		if err := c.Client().Resources().Get(ctx, "fluent-bit", logNS, &cm); err != nil {
+			t.Fatalf("Failed to get fluent-bit ConfigMap: %v", err)
+		}
+		cfg := cm.Data["fluent-bit.yaml"]
+		for _, want := range []string{"name: grep", "regex: log ERROR", "name: modify", "custom_field custom_value"} {
+			if !strings.Contains(cfg, want) {
+				t.Fatalf("Expected %q in fluent-bit config, not found", want)
+			}
+		}
+		t.Log("Verified: custom filters are correctly configured in fluent-bit")
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(logNS).Delete(ctx, cr); err != nil {
+			t.Logf("Warning: failed to delete MarklogicCluster: %v", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logNS}}); err != nil {
+			t.Logf("Warning: failed to delete namespace %s: %v", logNS, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -58,6 +58,7 @@ func cleanupLogNS(ctx context.Context, t *testing.T, _ *envconf.Config) {
 // TestLogCollectionDisabled verifies that fluent-bit is NOT created when
 // LogCollection.Enabled is false.
 func TestLogCollectionDisabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Disabled").WithLabel("type", "log-collection-disabled")
 
 	cr := &marklogicv1.MarklogicCluster{
@@ -133,6 +134,7 @@ func TestLogCollectionDisabled(t *testing.T) {
 // TestLogCollectionPartialLogs verifies that only the requested log files are configured
 // in the fluent-bit ConfigMap.
 func TestLogCollectionPartialLogs(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Partial Logs").WithLabel("type", "log-collection-partial")
 
 	cr := &marklogicv1.MarklogicCluster{
@@ -225,6 +227,7 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 // TestLogCollectionCustomResources verifies that custom resource requests/limits for the
 // fluent-bit sidecar are applied correctly.
 func TestLogCollectionCustomResources(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Custom Resources").WithLabel("type", "log-collection-resources")
 
 	customRes := &corev1.ResourceRequirements{
@@ -324,6 +327,7 @@ func TestLogCollectionCustomResources(t *testing.T) {
 // TestLogCollectionCustomFilters verifies that custom fluent-bit filter configuration
 // is correctly written to the fluent-bit ConfigMap.
 func TestLogCollectionCustomFilters(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Custom Filters").WithLabel("type", "log-collection-filters")
 
 	customFilters := `- name: grep

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -88,6 +88,7 @@ func TestLogCollectionDisabled(t *testing.T) {
 	feature.Assess("Pod created without fluent-bit container", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
 		if err := utils.WaitForPod(ctx, t, client, logNS, "lognode-0", 120*time.Second); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatalf("Failed to wait for pod: %v", err)
 		}
 		var pod corev1.Pod
@@ -176,6 +177,7 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 	feature.Assess("Pod created with fluent-bit container", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
 		if err := utils.WaitForPod(ctx, t, client, logNS, "lognode-0", 120*time.Second); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatalf("Failed to wait for pod: %v", err)
 		}
 		var pod corev1.Pod
@@ -275,6 +277,7 @@ func TestLogCollectionCustomResources(t *testing.T) {
 
 	feature.Assess("Pod created with custom resources", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), logNS, "lognode-0", 120*time.Second); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatalf("Failed to wait for pod: %v", err)
 		}
 		return ctx
@@ -373,6 +376,7 @@ func TestLogCollectionCustomFilters(t *testing.T) {
 
 	feature.Assess("Pod created with custom filters", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		if err := utils.WaitForPod(ctx, t, c.Client(), logNS, "lognode-0", 120*time.Second); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatalf("Failed to wait for pod: %v", err)
 		}
 		return ctx

--- a/test/e2e-helm/7_log_collection_test.go
+++ b/test/e2e-helm/7_log_collection_test.go
@@ -80,6 +80,7 @@ func TestLogCollectionDisabled(t *testing.T) {
 			wait.WithTimeout(3*time.Minute),
 			wait.WithInterval(5*time.Second),
 		); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatal(err)
 		}
 		return ctx
@@ -169,6 +170,7 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 			wait.WithTimeout(3*time.Minute),
 			wait.WithInterval(5*time.Second),
 		); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatal(err)
 		}
 		return ctx
@@ -270,6 +272,7 @@ func TestLogCollectionCustomResources(t *testing.T) {
 			wait.WithTimeout(3*time.Minute),
 			wait.WithInterval(5*time.Second),
 		); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatal(err)
 		}
 		return ctx
@@ -369,6 +372,7 @@ func TestLogCollectionCustomFilters(t *testing.T) {
 			wait.WithTimeout(3*time.Minute),
 			wait.WithInterval(5*time.Second),
 		); err != nil {
+			logDiagnostics(t, logNS)
 			t.Fatal(err)
 		}
 		return ctx

--- a/test/e2e-helm/8_metrics_test.go
+++ b/test/e2e-helm/8_metrics_test.go
@@ -38,6 +38,7 @@ const (
 // The Helm chart installs with metrics.secure=false which exposes HTTP on :8080
 // with no authentication required.
 func TestMetricsEndpointInsecure(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Metrics Endpoint — Insecure (namespace-scoped)").
 		WithLabel("type", "metrics")
 

--- a/test/e2e-helm/8_metrics_test.go
+++ b/test/e2e-helm/8_metrics_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	// metricsServiceName is the name of the metrics Service installed by the Helm chart.
+	metricsServiceName = "marklogic-operator-controller-manager-metrics-service"
+
+	// metricsLocalPort is the local port used for kubectl port-forward.
+	// Using a different local port from the main e2e suite to avoid conflicts if run simultaneously.
+	metricsLocalPort = "28080"
+
+	// metricsRemotePort is the port the metrics server listens on when metrics.secure=false.
+	metricsRemotePort = "8080"
+)
+
+// TestMetricsEndpointInsecure verifies that the insecure (HTTP) metrics endpoint
+// returns valid Prometheus output when the operator is installed with
+// metrics.secure=false (the only supported mode for namespace-scoped installs).
+//
+// In namespace-scoped mode the ClusterRole required for Kubernetes TokenReview/
+// SubjectAccessReview is not available, so metrics.secure=true is unsupported.
+// The Helm chart installs with metrics.secure=false which exposes HTTP on :8080
+// with no authentication required.
+func TestMetricsEndpointInsecure(t *testing.T) {
+	feature := features.New("Metrics Endpoint — Insecure (namespace-scoped)").
+		WithLabel("type", "metrics")
+
+	feature.Assess("Metrics endpoint is publicly accessible without authentication", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		pf, localAddr, cancel := startMetricsPortForward(t)
+		defer func() {
+			cancel()
+			_ = pf.Wait()
+		}()
+
+		waitForMetricsPortForward(t, localAddr)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			fmt.Sprintf("http://%s/metrics", localAddr), nil)
+		if err != nil {
+			t.Fatalf("failed to build metrics request: %v", err)
+		}
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("failed to GET /metrics: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected HTTP 200 (no auth required), got %d: %s", resp.StatusCode, body)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read metrics body: %v", err)
+		}
+		metrics := string(body)
+		if !strings.Contains(metrics, "# HELP") || !strings.Contains(metrics, "# TYPE") {
+			t.Errorf("response does not look like Prometheus text-format metrics:\n%.500s...", metrics)
+		}
+		if !strings.Contains(metrics, "controller_runtime_reconcile") {
+			t.Errorf("expected controller_runtime_reconcile metric not found")
+		}
+		t.Logf("Insecure metrics endpoint returned valid Prometheus output (%d bytes)", len(body))
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// startMetricsPortForward opens a kubectl port-forward tunnel to the metrics service
+// in the operator namespace (helmNS). Returns the process, local address, and cancel func.
+func startMetricsPortForward(t *testing.T) (*exec.Cmd, string, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	// #nosec G204 — helmNS, metricsServiceName, metricsLocalPort, metricsRemotePort are package constants
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward",
+		"-n", helmNS,
+		"svc/"+metricsServiceName,
+		metricsLocalPort+":"+metricsRemotePort,
+	)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("failed to start port-forward for %s: %v", metricsServiceName, err)
+	}
+	t.Logf("port-forward started: localhost:%s → %s/%s:%s", metricsLocalPort, helmNS, metricsServiceName, metricsRemotePort)
+	return cmd, "localhost:" + metricsLocalPort, cancel
+}
+
+// waitForMetricsPortForward polls until the forwarded TCP port accepts connections.
+func waitForMetricsPortForward(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("port-forward to %s did not become ready within 30s", addr)
+}

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -126,7 +126,7 @@ func TestMain(m *testing.M) {
 				"--namespace", helmNS,
 				"--create-namespace",
 				"--set", "scope.type=namespace",
-				"--set", fmt.Sprintf("scope.watchNamespaces=%s", watchedNamespaces),
+				"--set", fmt.Sprintf("scope.watchNamespaces=%s", strings.ReplaceAll(watchedNamespaces, ",", "\\,")),
 				"--set", "metrics.secure=false",
 				"--wait",
 				"--timeout", "3m",

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,6 +69,69 @@ var (
 // Istio ambient mode is not used in this suite, so no extra labels are needed.
 func namespaceLabels() map[string]string {
 	return nil
+}
+
+// ── Test summary tracker ──────────────────────────────────────────────────────
+
+type testResult struct {
+	name   string
+	passed bool
+}
+
+var (
+	trackMu      sync.Mutex
+	trackedTests []testResult
+)
+
+// trackTest registers t in the global summary. Call it at the top of each Test* function.
+// t.Cleanup runs after the test (and all its sub-tests) complete, so t.Failed() is final.
+func trackTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		trackMu.Lock()
+		trackedTests = append(trackedTests, testResult{name: t.Name(), passed: !t.Failed()})
+		trackMu.Unlock()
+	})
+}
+
+// printTestSummary logs a structured summary of all tracked tests to stdout.
+func printTestSummary() {
+	trackMu.Lock()
+	results := make([]testResult, len(trackedTests))
+	copy(results, trackedTests)
+	trackMu.Unlock()
+
+	total := len(results)
+	passed := 0
+	var failed []string
+	for _, r := range results {
+		if r.passed {
+			passed++
+		} else {
+			failed = append(failed, r.name)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║               E2E-HELM TEST SUITE SUMMARY                   ║")
+	fmt.Println("╠══════════════════════════════════════════════════════════════╣")
+	fmt.Printf("║  Total  : %-51d║\n", total)
+	fmt.Printf("║  Passed : %-51d║\n", passed)
+	fmt.Printf("║  Failed : %-51d║\n", len(failed))
+	if len(failed) > 0 {
+		fmt.Println("╠══════════════════════════════════════════════════════════════╣")
+		fmt.Println("║  Failed tests:                                               ║")
+		for _, name := range failed {
+			// Truncate long names to fit the box
+			if len(name) > 49 {
+				name = name[:46] + "..."
+			}
+			fmt.Printf("║    ✗ %-57s║\n", name)
+		}
+	}
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
 }
 
 // logDiagnostics dumps pods, statefulsets, services, and MarklogicCluster resources
@@ -251,5 +315,7 @@ func TestMain(m *testing.M) {
 		},
 	)
 
-	os.Exit(testEnv.Run(m))
+	exitCode := testEnv.Run(m)
+	printTestSummary()
+	os.Exit(exitCode)
 }

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	e2eutils "sigs.k8s.io/e2e-framework/pkg/utils"
 )
 
 // helmNS is the namespace the operator is installed into.
@@ -67,6 +68,27 @@ var (
 // Istio ambient mode is not used in this suite, so no extra labels are needed.
 func namespaceLabels() map[string]string {
 	return nil
+}
+
+// logDiagnostics dumps pods, statefulsets, services, and MarklogicCluster resources
+// for the given namespace, plus the last 50 lines of the operator pod logs.
+// Call this immediately before a fatal pod-readiness assertion to get actionable context.
+func logDiagnostics(t *testing.T, ns string) {
+	t.Helper()
+	for _, cmd := range []string{
+		fmt.Sprintf("kubectl get pods -n %s -o wide", ns),
+		fmt.Sprintf("kubectl get statefulsets -n %s", ns),
+		fmt.Sprintf("kubectl get services -n %s", ns),
+		fmt.Sprintf("kubectl get marklogicclusters -n %s", ns),
+	} {
+		p := e2eutils.RunCommand(cmd)
+		t.Logf("$ %s\n%s", cmd, p.Result())
+	}
+	// Operator logs give context on reconciliation failures and CrashLoopBackOff.
+	p := e2eutils.RunCommand(
+		fmt.Sprintf("kubectl logs -n %s -l control-plane=controller-manager --tail=50 --prefix=true", helmNS),
+	)
+	t.Logf("Operator logs (last 50 lines):\n%s", p.Result())
 }
 
 func TestMain(m *testing.M) {

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+// Package e2ehelm contains end-to-end tests for the MarkLogic Operator installed via Helm
+// in namespace-scoped mode (scope.type=namespace).
+//
+// Unlike the test/e2e package — which deploys the operator via `make deploy` (kustomize,
+// cluster-scoped ClusterRole/ClusterRoleBinding) and then patches WATCH_NAMESPACE at
+// runtime — this package installs the operator using the Helm chart with:
+//
+//	scope.type=namespace
+//	scope.watchNamespaces=<watched namespaces>
+//	metrics.secure=false
+//
+// This means the operator runs with only Role/RoleBinding per watched namespace and
+// NO ClusterRole backstop, which is the only way to truly validate namespace-scoped RBAC.
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/conf"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+// helmNS is the namespace the operator is installed into.
+const helmNS = "marklogic-operator-system"
+
+// helmRelease is the Helm release name used for install/uninstall.
+const helmRelease = "marklogic-operator"
+
+// helmChart is the path to the local chart (relative to repo root, where make runs).
+const helmChart = "charts/marklogic-operator-kubernetes"
+
+// watchedNamespaces is the comma-separated list of namespaces the operator watches.
+// Every test namespace in this suite must appear here — the namespace-scoped operator
+// only has a Role/RoleBinding in these namespaces (no ClusterRole backstop).
+const watchedNamespaces = "ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log"
+
+var (
+	testEnv        env.Environment
+	dockerImage    = os.Getenv("E2E_DOCKER_IMAGE")
+	marklogicImage = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
+
+	// Shared credentials and container name used across all test files in this package.
+	adminUsername   = "admin"
+	adminPassword   = "Admin@8001"
+	mlContainerName = "marklogic-server"
+	replicas        = int32(1)
+)
+
+// namespaceLabels returns labels to apply to test namespaces.
+// Istio ambient mode is not used in this suite, so no extra labels are needed.
+func namespaceLabels() map[string]string {
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	path := conf.ResolveKubeConfigFile()
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("Failed to create config: %s", err)
+	}
+	cfg = cfg.WithKubeconfigFile(path)
+	testEnv = env.NewWithConfig(cfg)
+
+	log.Printf("e2e-helm: docker image: %s", dockerImage)
+	log.Printf("e2e-helm: marklogic image: %s", marklogicImage)
+	log.Printf("e2e-helm: watched namespaces: %s", watchedNamespaces)
+
+	testEnv.Setup(
+		// Ensure the operator namespace is clean before installing.
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			log.Printf("Ensuring clean operator namespace: %s", helmNS)
+			client := cfg.Client()
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: helmNS}}
+			if err := client.Resources().Get(ctx, helmNS, "", ns); err == nil {
+				log.Printf("Deleting existing namespace %s", helmNS)
+				_ = client.Resources().Delete(ctx, ns)
+				for i := 0; i < 60; i++ {
+					if err := client.Resources().Get(ctx, helmNS, "", ns); apierrors.IsNotFound(err) {
+						log.Printf("Namespace %s deleted", helmNS)
+						break
+					} else if i == 59 {
+						return ctx, fmt.Errorf("timeout waiting for namespace %s deletion", helmNS)
+					}
+					time.Sleep(1 * time.Second)
+				}
+			}
+			return ctx, nil
+		},
+		envfuncs.CreateNamespace(helmNS),
+
+		// Change working directory to the repo root (same pattern as test/e2e).
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if err := os.Chdir("../.."); err != nil {
+				return ctx, fmt.Errorf("failed to chdir to repo root: %w", err)
+			}
+			wd, _ := os.Getwd()
+			log.Printf("Working directory: %s", wd)
+			return ctx, nil
+		},
+
+		// Install the operator via Helm in namespace-scoped mode.
+		// scope.type=namespace  → Role/RoleBinding per watched namespace (no ClusterRole)
+		// metrics.secure=false  → HTTP :8080 (ClusterRole for TokenReview not available)
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			log.Printf("Installing operator via Helm (scope=namespace, metrics.secure=false)...")
+
+			args := []string{
+				"upgrade", "--install", helmRelease, helmChart,
+				"--namespace", helmNS,
+				"--create-namespace",
+				"--set", "scope.type=namespace",
+				"--set", fmt.Sprintf("scope.watchNamespaces=%s", watchedNamespaces),
+				"--set", "metrics.secure=false",
+				"--wait",
+				"--timeout", "3m",
+			}
+			if dockerImage != "" {
+				// IMAGE is of the form repo/name:tag — split into repository and tag.
+				parts := strings.SplitN(dockerImage, ":", 2)
+				args = append(args, "--set", "controllerManager.manager.image.repository="+parts[0])
+				if len(parts) == 2 {
+					args = append(args, "--set", "controllerManager.manager.image.tag="+parts[1])
+				}
+				args = append(args, "--set", "controllerManager.manager.image.pullPolicy=Never")
+			}
+
+			// #nosec G204 — args are constructed from known constants and validated env vars
+			cmd := exec.Command("helm", args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return ctx, fmt.Errorf("helm install failed: %w", err)
+			}
+			log.Printf("Helm install succeeded")
+			return ctx, nil
+		},
+
+		// Wait for the operator Deployment to be available.
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			log.Println("Waiting for operator deployment to be available...")
+			client := cfg.Client()
+			if err := wait.For(
+				conditions.New(client.Resources()).DeploymentConditionMatch(
+					&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+						Name:      "marklogic-operator-controller-manager",
+						Namespace: helmNS,
+					}},
+					appsv1.DeploymentAvailable,
+					corev1.ConditionTrue,
+				),
+				wait.WithTimeout(3*time.Minute),
+				wait.WithInterval(5*time.Second),
+			); err != nil {
+				return ctx, fmt.Errorf("operator deployment not available: %w", err)
+			}
+			log.Println("Operator deployment is available")
+			return ctx, nil
+		},
+	)
+
+	testEnv.Finish(
+		// Uninstall the Helm release.
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			log.Printf("Uninstalling Helm release %s", helmRelease)
+			// #nosec G204 — helmRelease and helmNS are package constants
+			cmd := exec.Command("helm", "uninstall", helmRelease, "--namespace", helmNS, "--ignore-not-found")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				log.Printf("Warning: helm uninstall failed: %v", err)
+			}
+			return ctx, nil
+		},
+		envfuncs.DeleteNamespace(helmNS),
+	)
+
+	os.Exit(testEnv.Run(m))
+}

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -132,11 +132,17 @@ func TestMain(m *testing.M) {
 				"--timeout", "3m",
 			}
 			if dockerImage != "" {
-				// IMAGE is of the form repo/name:tag — split into repository and tag.
-				parts := strings.SplitN(dockerImage, ":", 2)
-				args = append(args, "--set", "controllerManager.manager.image.repository="+parts[0])
-				if len(parts) == 2 {
-					args = append(args, "--set", "controllerManager.manager.image.tag="+parts[1])
+				// Split on the last ':' that appears after the last '/' so that registry
+				// ports (e.g. registry:5000/repo/image:tag) are handled correctly.
+				repo := dockerImage
+				tag := ""
+				if idx := strings.LastIndex(dockerImage, ":"); idx > strings.LastIndex(dockerImage, "/") {
+					repo = dockerImage[:idx]
+					tag = dockerImage[idx+1:]
+				}
+				args = append(args, "--set", "controllerManager.manager.image.repository="+repo)
+				if tag != "" {
+					args = append(args, "--set", "controllerManager.manager.image.tag="+tag)
 				}
 				args = append(args, "--set", "controllerManager.manager.image.pullPolicy=Never")
 			}

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -105,6 +105,21 @@ func TestMain(m *testing.M) {
 		},
 		envfuncs.CreateNamespace(helmNS),
 
+		// Pre-create all watched namespaces so the Helm chart can create
+		// Role/RoleBinding in them during install.
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			client := cfg.Client()
+			for _, ns := range strings.Split(watchedNamespaces, ",") {
+				if err := client.Resources().Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: ns},
+				}); err != nil && !apierrors.IsAlreadyExists(err) {
+					return ctx, fmt.Errorf("failed to create watched namespace %s: %w", ns, err)
+				}
+				log.Printf("Watched namespace ready: %s", ns)
+			}
+			return ctx, nil
+		},
+
 		// Change working directory to the repo root (same pattern as test/e2e).
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 			if err := os.Chdir("../.."); err != nil {
@@ -199,6 +214,19 @@ func TestMain(m *testing.M) {
 			return ctx, nil
 		},
 		envfuncs.DeleteNamespace(helmNS),
+
+		// Delete all watched namespaces created during Setup.
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			client := cfg.Client()
+			for _, ns := range strings.Split(watchedNamespaces, ",") {
+				if err := client.Resources().Delete(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: ns},
+				}); err != nil && !apierrors.IsNotFound(err) {
+					log.Printf("Warning: failed to delete watched namespace %s: %v", ns, err)
+				}
+			}
+			return ctx, nil
+		},
 	)
 
 	os.Exit(testEnv.Run(m))

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -132,6 +132,10 @@ func TestMain(m *testing.M) {
 				"--timeout", "3m",
 			}
 			if dockerImage != "" {
+				// Reject shell metacharacters before incorporating the env var into args.
+				if strings.ContainsAny(dockerImage, ";|&$`(){}[]<>") {
+					return ctx, fmt.Errorf("E2E_DOCKER_IMAGE contains invalid characters: %s", dockerImage)
+				}
 				// Split on the last ':' that appears after the last '/' so that registry
 				// ports (e.g. registry:5000/repo/image:tag) are handled correctly.
 				repo := dockerImage
@@ -147,7 +151,7 @@ func TestMain(m *testing.M) {
 				args = append(args, "--set", "controllerManager.manager.image.pullPolicy=Never")
 			}
 
-			// #nosec G204 — args are constructed from known constants and validated env vars
+			// #nosec G204 — fixed args are package constants; E2E_DOCKER_IMAGE is validated above
 			cmd := exec.Command("helm", args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/test/test_data/helm_dnode_zero_certs/server.cnf
+++ b/test/test_data/helm_dnode_zero_certs/server.cnf
@@ -1,0 +1,16 @@
+# Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+[req]
+default_md = sha256
+prompt = no
+req_extensions = v3_ext
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+CN = dnode-0.dnode.ml-ns-tls-ednode.svc.cluster.local
+OU=MarkLogic
+
+[v3_ext]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = critical,serverAuth,clientAuth
+subjectAltName = DNS:localhost, DNS:dnode-0.dnode.ml-ns-tls-ednode.svc.cluster.local

--- a/test/test_data/helm_enode_zero_certs/server.cnf
+++ b/test/test_data/helm_enode_zero_certs/server.cnf
@@ -1,0 +1,16 @@
+# Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+[req]
+default_md = sha256
+prompt = no
+req_extensions = v3_ext
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+CN = enode-0.enode.ml-ns-tls-ednode.svc.cluster.local
+OU=MarkLogic
+
+[v3_ext]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = critical,serverAuth,clientAuth
+subjectAltName = DNS:localhost, DNS:enode-0.enode.ml-ns-tls-ednode.svc.cluster.local

--- a/test/test_data/helm_pod_one_certs/server.cnf
+++ b/test/test_data/helm_pod_one_certs/server.cnf
@@ -1,0 +1,16 @@
+# Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+[req]
+default_md = sha256
+prompt = no
+req_extensions = v3_ext
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+CN = marklogic-1.marklogic.ml-ns-tls-named.svc.cluster.local
+OU=MarkLogic
+
+[v3_ext]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = critical,serverAuth,clientAuth
+subjectAltName = DNS:localhost, DNS:marklogic-1.marklogic.ml-ns-tls-named.svc.cluster.local

--- a/test/test_data/helm_pod_zero_certs/server.cnf
+++ b/test/test_data/helm_pod_zero_certs/server.cnf
@@ -1,0 +1,16 @@
+# Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+[req]
+default_md = sha256
+prompt = no
+req_extensions = v3_ext
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+CN = marklogic-0.marklogic.ml-ns-tls-named.svc.cluster.local
+OU=MarkLogic
+
+[v3_ext]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = critical,serverAuth,clientAuth
+subjectAltName = DNS:localhost, DNS:marklogic-0.marklogic.ml-ns-tls-named.svc.cluster.local


### PR DESCRIPTION
This pull request introduces a new Helm-based, namespace-scoped end-to-end (e2e) test suite for the MarkLogic Kubernetes Operator, along with significant updates to the CI pipeline and documentation to support and describe these tests. The new suite validates that the operator functions correctly when installed via Helm in namespace-scoped mode (with only Role/RoleBinding and no ClusterRole), which is not possible to verify using the existing kustomize-based e2e tests. The Jenkins pipeline is updated to allow running these tests automatically, and documentation is expanded to clarify the differences between cluster-scoped and namespace-scoped testing.

**Helm Namespace-Scoped e2e Test Suite:**

* Added a new test directory `test/e2e-helm` with tests to verify operator readiness, cluster reconciliation, and RBAC correctness in namespace-scoped mode, ensuring no ClusterRole/ClusterRoleBinding is present and Roles/RoleBindings are correctly configured for watched namespaces. [[1]](diffhunk://#diff-861eeb7ade73791966607b2da5dd8ccdf672fbbd5799bf926ff2a94f5af9fd21R1-R83) [[2]](diffhunk://#diff-8d76f5d19676d557ca9dd728cc78de9bf6bbd20628c28250613e40cee2d4d37dR1-R118) [[3]](diffhunk://#diff-db49ce579fbcbcd61df4e8d2ff035df3718f0563a222d1f860085fae23f6ff8eR1-R104)
* Updated the `Makefile` with a new target `e2e-test-helm-namespace` to run these tests, and added documentation for this flow in `test/README.md`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R180-R184) [[2]](diffhunk://#diff-5de36acd90308dc62abf7855a686ee7052ffb6e762c756fd735fb0c9fbd9595dL3-R105)

**CI/CD Pipeline Integration:**

* Modified the `Jenkinsfile` to add a new boolean parameter `VERIFY_HELM_NAMESPACE_SCOPED` and new pipeline stages (`Helm-NS-Minikube-Setup`, `Run-Helm-NS-e2e-Tests`, `Helm-NS-Cleanup`) to support running the namespace-scoped e2e tests in CI. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R164-R169) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R240) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R303-R331)
* Updated scheduled (cron) builds to include the Helm namespace-scoped tests alongside existing test triggers.

**Documentation Improvements:**

* Expanded `test/README.md` to clearly explain the differences between the cluster-scoped and Helm namespace-scoped test suites, including setup, environment variables, and how to run specific test types in each suite.

These changes ensure robust automated validation of namespace-scoped deployments via Helm, which is critical for security-conscious environments that cannot grant cluster-wide privileges.