### PR TITLE
MLE-29157 : Bug Fix-Test-metrics

### DIFF
--- a/test/e2e/8_metrics_test.go
+++ b/test/e2e/8_metrics_test.go
@@ -32,7 +32,7 @@ const (
 	metricsReaderSA           = "metrics-reader-e2e"
 	metricsReaderCRB          = "metrics-reader-e2e-binding"
 	metricsReaderRole         = "metrics-reader"
-	metricsServiceName        = "controller-manager-metrics-service"
+	metricsServiceName        = "marklogic-operator-controller-manager-metrics-service"
 	metricsLocalSecurePort    = "19443"
 	metricsRemoteSecurePort   = "8443"
 	metricsLocalInsecurePort  = "18080"
@@ -330,11 +330,22 @@ func startPortForward(t *testing.T, ns, svc, localPort, remotePort string) (*exe
 		"svc/"+svc,
 		localPort+":"+remotePort,
 	)
+	// Capture kubectl's stdout/stderr so failures (e.g. "service not found")
+	// surface immediately instead of presenting only as a 30s readiness timeout.
+	var pfOut strings.Builder
+	cmd.Stdout = &pfOut
+	cmd.Stderr = &pfOut
 	if err := cmd.Start(); err != nil {
 		cancel()
 		t.Fatalf("failed to start port-forward for %s: %v", svc, err)
 	}
 	t.Logf("port-forward started: localhost:%s → %s:%s", localPort, svc, remotePort)
+	// Log kubectl output on test failure to aid debugging.
+	t.Cleanup(func() {
+		if out := strings.TrimSpace(pfOut.String()); out != "" {
+			t.Logf("kubectl port-forward output for svc/%s:\n%s", svc, out)
+		}
+	})
 	return cmd, "localhost:" + localPort, cancel
 }
 


### PR DESCRIPTION
This pull request makes improvements to the end-to-end metrics test for better clarity and debugging. The most important changes include renaming a service constant for accuracy and enhancing the port-forwarding logic to capture and log output, making test failures easier to diagnose.

**Test reliability and debugging improvements:**

* The `metricsServiceName` constant in `test/e2e/8_metrics_test.go` was renamed to `marklogic-operator-controller-manager-metrics-service` to accurately reflect the actual service name.
* The `startPortForward` function now captures `kubectl`'s stdout and stderr, and logs this output on test failure to aid in debugging port-forwarding issues.