### PR TITLE
MLE-29173 : Fix E2E Helm Haproxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,8 +236,8 @@ pipeline {
         string(name: 'VERSION', defaultValue: '1.2.0', description: 'Version to tag the image with.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
-        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: false, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
-        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: true, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
     stages {
@@ -248,36 +248,24 @@ pipeline {
         }
 
         stage('Run-tests') {
-            when {
-                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
-            }
             steps {
                 runTests()
             }
         }
 
         stage('Run-Minikube-Setup') {
-            when {
-                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
-            }
             steps {
                 runMinikubeSetup()
             }
         }
 
         stage('Run-e2e-Tests') {
-            when {
-                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
-            }
             steps {
                 runE2eTests()
             }
         }
 
         stage('Cleanup Environment') {
-            when {
-                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
-            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     runMinikubeCleanup()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,8 +236,8 @@ pipeline {
         string(name: 'VERSION', defaultValue: '1.2.0', description: 'Version to tag the image with.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
-        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
-        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: false, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: true, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
     }
 
     stages {
@@ -248,24 +248,36 @@ pipeline {
         }
 
         stage('Run-tests') {
+            when {
+                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
             steps {
                 runTests()
             }
         }
 
         stage('Run-Minikube-Setup') {
+            when {
+                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
             steps {
                 runMinikubeSetup()
             }
         }
 
         stage('Run-e2e-Tests') {
+            when {
+                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
             steps {
                 runE2eTests()
             }
         }
 
         stage('Cleanup Environment') {
+            when {
+                expression { return !params.VERIFY_HELM_NAMESPACE_SCOPED }
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     runMinikubeCleanup()

--- a/test/e2e-helm/6_haproxy_test.go
+++ b/test/e2e-helm/6_haproxy_test.go
@@ -140,9 +140,13 @@ func TestHAProxyPathBasedEnabled(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		// Delete the actual MarklogicCluster created in Setup. The CR's metadata
+		// name must match what was created (see cr.ObjectMeta above) — using a
+		// different name results in a silent NotFound and the owned pods never
+		// get garbage-collected, causing the wait below to time out.
 		mlc := &marklogicv1.MarklogicCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ml",
+				Name:      cr.Name,
 				Namespace: haProxyPathNS,
 			},
 		}


### PR DESCRIPTION
This pull request updates the teardown logic in the `TestHAProxyPathBasedEnabled` test to ensure that the correct `MarklogicCluster` resource is deleted. This prevents orphaned pods and potential test timeouts.

Test reliability improvements:

* Updated the `feature.Teardown` block in `6_haproxy_test.go` to delete the `MarklogicCluster` using the actual name assigned during setup (`cr.Name`), instead of a hardcoded value, ensuring proper cleanup and avoiding silent failures.