### PR TITLE
MLE-29504: Scan all dependent container images in the Black Duck pipeline stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,13 +167,33 @@ void runHelmNamespaceScopedE2eTests() {
     """
 }
 
+// Dynamically extracts dependent container image references from their canonical
+// sources and triggers the BlackDuck scan job with the full CONTAINER_IMAGES list.
+// PUBLISH_IMAGE=true also prepends the published operator registry image.
 void runBlackDuckScan() {
-    // Trigger BlackDuck scan job with CONTAINER_IMAGES parameter when params.PUBLISH_IMAGE is true
+    def fluentBitImage = sh(returnStdout: true, script: "grep -E '^export FLUENT_BIT_IMAGE' Makefile | cut -d'=' -f2 | tr -d ' '").trim()
+    def haProxyImage   = sh(returnStdout: true, script: "grep -oE 'haproxytech/haproxy-alpine:[0-9.]+' Makefile | head -1").trim()
+    def ubi9Image      = sh(returnStdout: true, script: "grep -oE 'redhat/ubi9:[0-9.]+' pkg/k8sutil/statefulset.go | head -1").trim()
+
+    if (!fluentBitImage) { error "runBlackDuckScan: could not resolve FLUENT_BIT_IMAGE from Makefile" }
+    if (!haProxyImage)   { error "runBlackDuckScan: could not resolve HAProxy image from Makefile" }
+    if (!ubi9Image)      { error "runBlackDuckScan: could not resolve UBI9 image from pkg/k8sutil/statefulset.go" }
+
+    def dependentImages = "${fluentBitImage},${haProxyImage},${ubi9Image},${params.E2E_MARKLOGIC_IMAGE_VERSION}"
+
+    def containerImages
     if (params.PUBLISH_IMAGE) {
-        build job: 'securityscans/Blackduck/KubeNinjas/kubernetes-operator', wait: false, parameters: [ string(name: 'branch', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${operatorRegistry}/${operatorRepo}:${VERSION}-${branchNameTag}-${timeStamp}") ]
+        containerImages = "${operatorRegistry}/${operatorRepo}:${VERSION}-${branchNameTag}-${timeStamp},${dependentImages}"
     } else {
-        build job: 'securityscans/Blackduck/KubeNinjas/kubernetes-operator', wait: false, parameters: [ string(name: 'branch', value: "${env.BRANCH_NAME}") ]
+        containerImages = dependentImages
     }
+
+    build job: 'securityscans/Blackduck/KubeNinjas/kubernetes-operator',
+          wait: false,
+          parameters: [
+              string(name: 'branch',           value: "${env.BRANCH_NAME}"),
+              string(name: 'CONTAINER_IMAGES', value: containerImages)
+          ]
 }
 
 /**


### PR DESCRIPTION
Jira: https://progresssoftware.atlassian.net/browse/MLE-29504

## Summary

The Jenkins pipeline's Black Duck scan stage previously passed only the
published operator image (and only when PUBLISH_IMAGE=true) to the
CONTAINER_IMAGES parameter of the downstream scan job. Dependent runtime
images — Fluent Bit, HAProxy, UBI9, and the MarkLogic server image — were
never included, leaving the majority of the operator's attack surface
unscanned.

The updated runBlackDuckScan() function dynamically extracts each dependent
image reference from its canonical source (FLUENT_BIT_IMAGE from Makefile,
haproxytech/haproxy-alpine from Makefile, redhat/ubi9 from
pkg/k8sutil/statefulset.go), combines them with the pipeline's
E2E_MARKLOGIC_IMAGE_VERSION parameter, and always passes the full list as
CONTAINER_IMAGES. When PUBLISH_IMAGE=true the published operator registry
image is prepended to the list. The function now also fails fast with a
descriptive error if any image reference cannot be resolved at build time.

## Root cause

runBlackDuckScan() only conditionally set CONTAINER_IMAGES (operator image
only), and passed no images at all when PUBLISH_IMAGE was false.

## Fix

Rewrite runBlackDuckScan() to dynamically resolve all dependent image
references from their source files and always pass the full CONTAINER_IMAGES
list to the downstream scan job.

## Validation

- go vet: pass
- go build: pass
- kustomize build: pass
- golangci-lint: skipped (binary not installed locally — pre-existing gap)
- go test: skipped (kubebuilder envtest binaries absent — pre-existing gap)
- Only Jenkinsfile modified; no Go source files changed