### PR TITLE
MLE-28304 : add-test-suites for Volume Resizing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,6 +275,11 @@ pipeline {
         stage('Run-e2e-Tests') {
             steps {
                 runE2eTests()
+                script {
+                    if (params.VERIFY_VOLUME_RESIZE) {
+                        runVolumeResizeE2eTests()
+                    }
+                }
             }
         }
 
@@ -328,50 +333,17 @@ pipeline {
             }
             steps {
                 runHelmNamespaceScopedE2eTests()
+                script {
+                    if (params.VERIFY_VOLUME_RESIZE) {
+                        runHelmVolumeResizeE2eTests()
+                    }
+                }
             }
         }
 
         stage('Helm-NS-Cleanup') {
             when {
                 expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false }
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    runMinikubeCleanup()
-                }
-            }
-        }
-
-        stage('Volume-Resize-Minikube-Setup') {
-            when {
-                expression { return params.VERIFY_VOLUME_RESIZE }
-            }
-            steps {
-                runMinikubeSetup()
-            }
-        }
-
-        stage('Run-Volume-Resize-e2e-Tests') {
-            when {
-                expression { return params.VERIFY_VOLUME_RESIZE }
-            }
-            steps {
-                runVolumeResizeE2eTests()
-            }
-        }
-
-        stage('Run-Helm-Volume-Resize-e2e-Tests') {
-            when {
-                expression { return params.VERIFY_VOLUME_RESIZE }
-            }
-            steps {
-                runHelmVolumeResizeE2eTests()
-            }
-        }
-
-        stage('Volume-Resize-Cleanup') {
-            when {
-                expression { return params.VERIFY_VOLUME_RESIZE }
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,18 @@ void runHelmNamespaceScopedE2eTests() {
     """
 }
 
+void runVolumeResizeE2eTests() {
+    sh """
+        make e2e-test-volume-resize IMG=${operatorRepo}:${VERSION}
+    """
+}
+
+void runHelmVolumeResizeE2eTests() {
+    sh """
+        make e2e-test-helm-volume-resize IMG=${operatorRepo}:${VERSION}
+    """
+}
+
 void runBlackDuckScan() {
     // Trigger BlackDuck scan job with CONTAINER_IMAGES parameter when params.PUBLISH_IMAGE is true
     if (params.PUBLISH_IMAGE) {
@@ -238,6 +250,7 @@ pipeline {
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
         booleanParam(name: 'VERIFY_ISTIO_AMBIENT', defaultValue: true, description: 'Run Istio ambient mode e2e tests (requires fresh minikube cluster with Istio)')
         booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_VOLUME_RESIZE', defaultValue: true, description: 'Run cluster-scoped + Helm-namespace-scoped volume-resize e2e tests (two namespaces in parallel each)')
     }
 
     stages {
@@ -321,6 +334,44 @@ pipeline {
         stage('Helm-NS-Cleanup') {
             when {
                 expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false }
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    runMinikubeCleanup()
+                }
+            }
+        }
+
+        stage('Volume-Resize-Minikube-Setup') {
+            when {
+                expression { return params.VERIFY_VOLUME_RESIZE }
+            }
+            steps {
+                runMinikubeSetup()
+            }
+        }
+
+        stage('Run-Volume-Resize-e2e-Tests') {
+            when {
+                expression { return params.VERIFY_VOLUME_RESIZE }
+            }
+            steps {
+                runVolumeResizeE2eTests()
+            }
+        }
+
+        stage('Run-Helm-Volume-Resize-e2e-Tests') {
+            when {
+                expression { return params.VERIFY_VOLUME_RESIZE }
+            }
+            steps {
+                runHelmVolumeResizeE2eTests()
+            }
+        }
+
+        stage('Volume-Resize-Cleanup') {
+            when {
+                expression { return params.VERIFY_VOLUME_RESIZE }
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,11 +275,6 @@ pipeline {
         stage('Run-e2e-Tests') {
             steps {
                 runE2eTests()
-                script {
-                    if (params.VERIFY_VOLUME_RESIZE) {
-                        runVolumeResizeE2eTests()
-                    }
-                }
             }
         }
 
@@ -333,11 +328,6 @@ pipeline {
             }
             steps {
                 runHelmNamespaceScopedE2eTests()
-                script {
-                    if (params.VERIFY_VOLUME_RESIZE) {
-                        runHelmVolumeResizeE2eTests()
-                    }
-                }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,13 @@ e2e-setup-minikube: kustomize controller-gen build docker-build
 	minikube addons enable ingress
 	minikube addons enable storage-provisioner
 	minikube addons enable default-storageclass
+	@echo "=====Enabling CSI hostpath driver (required for PVC volume expansion tests)"
+	minikube addons enable volumesnapshots
+	minikube addons enable csi-hostpath-driver
+	@echo "=====Making csi-hostpath-sc the default StorageClass (allowVolumeExpansion=true)"
+	kubectl patch storageclass standard       -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' || true
+	kubectl patch storageclass csi-hostpath-sc -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+	kubectl get storageclass
 	minikube image load $(IMG)
 	minikube image load $(E2E_MARKLOGIC_IMAGE_VERSION)
 	minikube image load "docker.io/haproxytech/haproxy-alpine:3.2"

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,11 @@ e2e-setup-minikube: kustomize controller-gen build docker-build
 	@echo "=====Making csi-hostpath-sc the default StorageClass (allowVolumeExpansion=true)"
 	kubectl patch storageclass standard       -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' || true
 	kubectl patch storageclass csi-hostpath-sc -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+	@echo "=====Ensuring csi-hostpath-sc has allowVolumeExpansion=true (some minikube versions ship it disabled)"
+	kubectl patch storageclass csi-hostpath-sc -p '{"allowVolumeExpansion":true}'
+	@echo "=====Verifying allowVolumeExpansion is set on csi-hostpath-sc"
+	@test "$$(kubectl get storageclass csi-hostpath-sc -o jsonpath='{.allowVolumeExpansion}')" = "true" \
+		|| (echo "ERROR: csi-hostpath-sc.allowVolumeExpansion is not true after patch" && exit 1)
 	kubectl get storageclass
 	minikube image load $(IMG)
 	minikube image load $(E2E_MARKLOGIC_IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ifeq ($(VERIFY_HUGE_PAGES), true)
 	minikube start
 
 	@echo "=====Running e2e test including hugepages test"
-	go test -v -count=1 -timeout 30m ./test/e2e -verifyHugePages
+	IMG=$(IMG) go test -v -count=1 -timeout 30m ./test/e2e -verifyHugePages
 
 	@echo "=====Resetting hugepages value to 0"
 	sudo sysctl -w vm.nr_hugepages=0
@@ -159,13 +159,13 @@ ifeq ($(VERIFY_HUGE_PAGES), true)
 	minikube start
 else
 	@echo "=====Running e2e test without hugepages test"
-	go test -v -count=1 -timeout 30m ./test/e2e
+	IMG=$(IMG) go test -v -count=1 -timeout 30m ./test/e2e
 endif
 
 .PHONY: e2e-test-istio  # Run Istio ambient mode e2e tests
 e2e-test-istio:
 	@echo "=====Running Istio ambient mode e2e tests"
-	E2E_ISTIO_AMBIENT=true go test -v -count=1 -timeout 30m ./test/e2e -run "Test(Istio|NonIstio)"
+	IMG=$(IMG) E2E_ISTIO_AMBIENT=true go test -v -count=1 -timeout 30m ./test/e2e -run "Test(Istio|NonIstio)"
 
 # NOTE: There is intentionally no `e2e-test-namespace` target here.
 # The `test/e2e` suite always deploys the operator via `make deploy`
@@ -178,7 +178,7 @@ e2e-test-istio:
 .PHONY: e2e-test-cluster  ## Run e2e tests against a cluster-scoped operator install (alias for `e2e-test`)
 e2e-test-cluster:
 	@echo "=====Running e2e tests in cluster-scoped mode"
-	go test -v -count=1 -timeout 30m ./test/e2e
+	IMG=$(IMG) go test -v -count=1 -timeout 30m ./test/e2e
 
 .PHONY: e2e-test-helm-namespace  ## Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole, insecure metrics on :8080)
 e2e-test-helm-namespace:
@@ -188,7 +188,7 @@ e2e-test-helm-namespace:
 .PHONY: e2e-test-volume-resize  ## Run ONLY the cluster-scoped volume resize test (two namespaces in parallel)
 e2e-test-volume-resize:
 	@echo "=====Running cluster-scoped volume-resize e2e test (parallel, 2 namespaces)====="
-	go test -v -count=1 -timeout 30m ./test/e2e -run TestVolumeResizeClusterScoped
+	IMG=$(IMG) go test -v -count=1 -timeout 30m ./test/e2e -run TestVolumeResizeClusterScoped
 
 .PHONY: e2e-test-helm-volume-resize  ## Run ONLY the namespace-scoped volume resize test via Helm (two watched namespaces in parallel)
 e2e-test-helm-volume-resize:

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,16 @@ e2e-test-helm-namespace:
 	@echo "=====Running namespace-scoped e2e tests via Helm chart====="
 	E2E_DOCKER_IMAGE=$(IMG) go test -v -count=1 -timeout 45m ./test/e2e-helm
 
+.PHONY: e2e-test-volume-resize  ## Run ONLY the cluster-scoped volume resize test (two namespaces in parallel)
+e2e-test-volume-resize:
+	@echo "=====Running cluster-scoped volume-resize e2e test (parallel, 2 namespaces)====="
+	go test -v -count=1 -timeout 30m ./test/e2e -run TestVolumeResizeClusterScoped
+
+.PHONY: e2e-test-helm-volume-resize  ## Run ONLY the namespace-scoped volume resize test via Helm (two watched namespaces in parallel)
+e2e-test-helm-volume-resize:
+	@echo "=====Running namespace-scoped volume-resize e2e test via Helm (parallel, 2 watched namespaces)====="
+	E2E_DOCKER_IMAGE=$(IMG) go test -v -count=1 -timeout 30m ./test/e2e-helm -run TestVolumeResizeNamespaceScoped
+
 .PHONY: e2e-setup-minikube
 e2e-setup-minikube: kustomize controller-gen build docker-build
 	minikube version

--- a/test/e2e-helm/9_volume_resize_test.go
+++ b/test/e2e-helm/9_volume_resize_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+// Volume Resize – Namespace-Scoped E2E Test (Helm)
+//
+// Validates that the operator — installed via the Helm chart with
+// scope.type=namespace and a watch list — can resize PVCs concurrently in
+// TWO DIFFERENT WATCHED NAMESPACES (ml-ns-resize-a, ml-ns-resize-b).
+//
+// Both target namespaces MUST be present in test/e2e-helm/main_test.go's
+// watchedNamespaces constant; otherwise the namespace-scoped operator has no
+// Role/RoleBinding there and reconciliation will silently no-op.
+//
+// Result summary:
+// At the end of the test a banner is printed for each namespace with
+// PASS/FAIL plus the initial / requested / observed PVC capacity, so the
+// outcome is easy to read at a glance in CI logs.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	frameworkutils "sigs.k8s.io/e2e-framework/pkg/utils"
+)
+
+// resizeNSNamespaces are the two parallel namespaces. They MUST be listed in
+// watchedNamespaces in main_test.go.
+var resizeNSNamespaces = []string{"ml-ns-resize-a", "ml-ns-resize-b"}
+
+const (
+	resizeNSClusterName = "ml-ns-resize-cluster"
+	resizeNSGroupName   = "node"
+	resizeNSInitialSize = "2Gi"
+	resizeNSTargetSize  = "3Gi"
+	resizeNSWaitTimeout = 15 * time.Minute
+)
+
+type resizeNSOutcome struct {
+	namespace    string
+	initialSize  string
+	requestSize  string
+	observedSize string
+	phase        string
+	passed       bool
+	failReason   string
+}
+
+// TestVolumeResizeNamespaceScoped resizes PVCs in two watched namespaces
+// concurrently and prints a clear pass/fail summary.
+func TestVolumeResizeNamespaceScoped(t *testing.T) {
+	trackTest(t)
+	feature := features.New("Volume Resize — Namespace-Scoped, Multi-Namespace").
+		WithLabel("type", "volume-resize-ns")
+
+	// ── Pre-flight: at least one StorageClass must allow expansion ────────────
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := assertNSStorageClassExpandable(ctx, c.Client()); err != nil {
+			t.Fatalf("Pre-flight failed: %v", err)
+		}
+		// Sanity: both target namespaces must be in the watch list.
+		for _, ns := range resizeNSNamespaces {
+			if !strings.Contains(watchedNamespaces, ns) {
+				t.Fatalf("namespace %s is not in watchedNamespaces (%s) — resize cannot be reconciled", ns, watchedNamespaces)
+			}
+		}
+		return ctx
+	})
+
+	// ── Create both clusters in parallel (namespaces already created in TestMain) ──
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources().GetScheme())
+
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(resizeNSNamespaces))
+		for _, ns := range resizeNSNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := createNSResizeCluster(ctx, client, ns); err != nil {
+					errCh <- fmt.Errorf("[%s] %w", ns, err)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Fatalf("Setup failed: %v", err)
+		}
+		return ctx
+	})
+
+	// ── Wait for node-0 in BOTH namespaces in parallel ────────────────────────
+	feature.Assess("MarkLogic pods Ready in both watched namespaces", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(resizeNSNamespaces))
+		for _, ns := range resizeNSNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := utils.WaitForPod(ctx, t, client, ns, "node-0", 5*time.Minute, true); err != nil {
+					logDiagnostics(t, ns)
+					errCh <- fmt.Errorf("[%s] node-0 not ready: %w", ns, err)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Fatalf("%v", err)
+		}
+		return ctx
+	})
+
+	// ── Trigger resize and verify outcome in parallel ─────────────────────────
+	feature.Assess("PVCs resized to target size in both watched namespaces", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+
+		var (
+			wg       sync.WaitGroup
+			mu       sync.Mutex
+			outcomes = make([]resizeNSOutcome, 0, len(resizeNSNamespaces))
+		)
+		for _, ns := range resizeNSNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				out := triggerNSResizeAndWait(ctx, t, client, ns)
+				mu.Lock()
+				outcomes = append(outcomes, out)
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		printNSResizeSummary(t, "Volume Resize — Namespace-Scoped (Helm)", outcomes)
+
+		for _, o := range outcomes {
+			if !o.passed {
+				dumpNSResizeDiagnostics(t, o.namespace)
+				t.Errorf("[%s] resize did NOT complete: %s", o.namespace, o.failReason)
+			}
+		}
+		return ctx
+	})
+
+	// ── Teardown: delete the two clusters (namespaces survive — they are watched) ──
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		for _, ns := range resizeNSNamespaces {
+			cluster := &marklogicv1.MarklogicCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: resizeNSClusterName, Namespace: ns},
+			}
+			if err := client.Resources(ns).Delete(ctx, cluster); err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("Warning: failed to delete cluster in %s: %v", ns, err)
+			}
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func assertNSStorageClassExpandable(ctx context.Context, client klient.Client) error {
+	scList := &storagev1.StorageClassList{}
+	if err := client.Resources().List(ctx, scList); err != nil {
+		return fmt.Errorf("list StorageClasses: %w", err)
+	}
+	for _, sc := range scList.Items {
+		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
+			return nil
+		}
+	}
+	return fmt.Errorf("no StorageClass with allowVolumeExpansion=true found; volume resize cannot be tested")
+}
+
+func createNSResizeCluster(ctx context.Context, client klient.Client, ns string) error {
+	r := int32(1)
+	cluster := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: resizeNSClusterName, Namespace: ns},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			Persistence: &marklogicv1.Persistence{
+				Enabled: true,
+				Size:    resizeNSInitialSize,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        resizeNSGroupName,
+					Replicas:    &r,
+					IsBootstrap: true,
+				},
+			},
+		},
+	}
+	if err := client.Resources(ns).Create(ctx, cluster); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create MarklogicCluster: %w", err)
+	}
+	return nil
+}
+
+func triggerNSResizeAndWait(ctx context.Context, t *testing.T, client klient.Client, ns string) resizeNSOutcome {
+	out := resizeNSOutcome{namespace: ns, initialSize: resizeNSInitialSize, requestSize: resizeNSTargetSize}
+
+	if size, err := minNSPVCCapacity(ctx, client, ns); err == nil {
+		out.initialSize = size
+	}
+
+	patch := []byte(fmt.Sprintf(`{"spec":{"persistence":{"size":"%s"}}}`, resizeNSTargetSize))
+	cluster := &marklogicv1.MarklogicCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: resizeNSClusterName, Namespace: ns},
+	}
+	if err := client.Resources(ns).Patch(ctx, cluster, k8s.Patch{PatchType: types.MergePatchType, Data: patch}); err != nil {
+		out.failReason = fmt.Sprintf("patch cluster: %v", err)
+		return out
+	}
+	t.Logf("[%s] patched MarklogicCluster persistence.size → %s", ns, resizeNSTargetSize)
+
+	deadline := time.Now().Add(resizeNSWaitTimeout)
+	for time.Now().Before(deadline) {
+		grp := &marklogicv1.MarklogicGroup{}
+		if err := client.Resources(ns).Get(ctx, resizeNSGroupName, ns, grp); err != nil {
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		if grp.Status.VolumeResizeStatus != nil {
+			out.phase = string(grp.Status.VolumeResizeStatus.Phase)
+		}
+		obs, _ := minNSPVCCapacity(ctx, client, ns)
+		out.observedSize = obs
+
+		if out.phase == string(marklogicv1.VolumeResizePhaseCompleted) && nsSizesEqual(obs, resizeNSTargetSize) {
+			out.passed = true
+			return out
+		}
+		if out.phase == string(marklogicv1.VolumeResizePhaseFailed) {
+			out.failReason = fmt.Sprintf("phase=Failed reason=%s msg=%s",
+				grp.Status.VolumeResizeStatus.Reason, grp.Status.VolumeResizeStatus.Message)
+			return out
+		}
+		t.Logf("[%s] resize in progress: phase=%s observed=%s target=%s", ns, out.phase, obs, resizeNSTargetSize)
+		time.Sleep(15 * time.Second)
+	}
+	out.failReason = fmt.Sprintf("timeout after %s (last phase=%s observed=%s)", resizeNSWaitTimeout, out.phase, out.observedSize)
+	return out
+}
+
+func minNSPVCCapacity(ctx context.Context, client klient.Client, ns string) (string, error) {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := client.Resources(ns).List(ctx, pvcs); err != nil {
+		return "", err
+	}
+	var min *resource.Quantity
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if !strings.HasPrefix(pvc.Name, "datadir-"+resizeNSGroupName+"-") {
+			continue
+		}
+		q, ok := pvc.Status.Capacity[corev1.ResourceStorage]
+		if !ok {
+			continue
+		}
+		if min == nil || q.Cmp(*min) < 0 {
+			qq := q.DeepCopy()
+			min = &qq
+		}
+	}
+	if min == nil {
+		return "", fmt.Errorf("no PVC capacity reported yet")
+	}
+	return min.String(), nil
+}
+
+func nsSizesEqual(a, b string) bool {
+	qa, errA := resource.ParseQuantity(a)
+	qb, errB := resource.ParseQuantity(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return qa.Cmp(qb) == 0
+}
+
+func printNSResizeSummary(t *testing.T, title string, outcomes []resizeNSOutcome) {
+	t.Helper()
+	line := strings.Repeat("=", 78)
+	t.Logf("\n%s\n  %s — RESULT SUMMARY\n%s", line, title, line)
+	for _, o := range outcomes {
+		status := "✅ PASS"
+		if !o.passed {
+			status = "❌ FAIL"
+		}
+		t.Logf("  [%-14s] %s  initial=%-6s  requested=%-6s  observed=%-6s  phase=%s",
+			o.namespace, status, o.initialSize, o.requestSize, o.observedSize, o.phase)
+		if !o.passed && o.failReason != "" {
+			t.Logf("                      reason: %s", o.failReason)
+		}
+	}
+	t.Logf("%s\n", line)
+}
+
+// dumpNSResizeDiagnostics prints PVCs, StatefulSet, MarklogicCluster /
+// MarklogicGroup CRs, recent Kubernetes events for the namespace, and the
+// last 200 lines of the operator pod logs. Called only when a resize fails
+// so passing tests stay quiet.
+func dumpNSResizeDiagnostics(t *testing.T, ns string) {
+	t.Helper()
+	line := strings.Repeat("-", 78)
+	t.Logf("\n%s\n  DIAGNOSTICS for namespace %s\n%s", line, ns, line)
+	for _, cmd := range []string{
+		fmt.Sprintf("kubectl get pvc -n %s -o wide", ns),
+		fmt.Sprintf("kubectl describe pvc -n %s", ns),
+		fmt.Sprintf("kubectl get statefulset -n %s -o wide", ns),
+		fmt.Sprintf("kubectl get pods -n %s -o wide", ns),
+		fmt.Sprintf("kubectl get marklogiccluster,marklogicgroup -n %s -o yaml", ns),
+		fmt.Sprintf("kubectl get events -n %s --sort-by=.lastTimestamp", ns),
+	} {
+		p := frameworkutils.RunCommand(cmd)
+		t.Logf("$ %s\n%s", cmd, p.Result())
+	}
+	p := frameworkutils.RunCommand(
+		fmt.Sprintf("kubectl logs -n %s -l control-plane=controller-manager --tail=200 --prefix=true", helmNS),
+	)
+	t.Logf("Operator logs (last 200 lines):\n%s", p.Result())
+	t.Logf("%s\n", line)
+}

--- a/test/e2e-helm/9_volume_resize_test.go
+++ b/test/e2e-helm/9_volume_resize_test.go
@@ -74,9 +74,15 @@ func TestVolumeResizeNamespaceScoped(t *testing.T) {
 		if err := assertNSStorageClassExpandable(ctx, c.Client()); err != nil {
 			t.Fatalf("Pre-flight failed: %v", err)
 		}
-		// Sanity: both target namespaces must be in the watch list.
+		// Sanity: both target namespaces must be in the watch list. Split on
+		// comma and compare trimmed entries for exact matches — a substring
+		// check would let "ml-ns-resize-a" match "ml-ns-resize-a2".
+		watched := make(map[string]struct{})
+		for _, n := range strings.Split(watchedNamespaces, ",") {
+			watched[strings.TrimSpace(n)] = struct{}{}
+		}
 		for _, ns := range resizeNSNamespaces {
-			if !strings.Contains(watchedNamespaces, ns) {
+			if _, ok := watched[ns]; !ok {
 				t.Fatalf("namespace %s is not in watchedNamespaces (%s) — resize cannot be reconciled", ns, watchedNamespaces)
 			}
 		}
@@ -189,12 +195,38 @@ func assertNSStorageClassExpandable(ctx context.Context, client klient.Client) e
 	if err := client.Resources().List(ctx, scList); err != nil {
 		return fmt.Errorf("list StorageClasses: %w", err)
 	}
+	var defaults []storagev1.StorageClass
 	for _, sc := range scList.Items {
-		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
-			return nil
+		if isNSDefaultStorageClass(sc) {
+			defaults = append(defaults, sc)
 		}
 	}
-	return fmt.Errorf("no StorageClass with allowVolumeExpansion=true found; volume resize cannot be tested")
+	switch len(defaults) {
+	case 0:
+		return fmt.Errorf("no default StorageClass found (annotation storageclass.kubernetes.io/is-default-class=true); volume resize cannot be tested")
+	case 1:
+		sc := defaults[0]
+		if sc.AllowVolumeExpansion == nil || !*sc.AllowVolumeExpansion {
+			return fmt.Errorf("default StorageClass %q has allowVolumeExpansion=false; volume resize cannot succeed", sc.Name)
+		}
+		return nil
+	default:
+		names := make([]string, 0, len(defaults))
+		for _, sc := range defaults {
+			names = append(names, sc.Name)
+		}
+		return fmt.Errorf("multiple default StorageClasses found (%s); cannot determine which one PVCs will bind to", strings.Join(names, ", "))
+	}
+}
+
+// isNSDefaultStorageClass reports whether sc carries either the GA or the
+// legacy beta default-class annotation set to "true".
+func isNSDefaultStorageClass(sc storagev1.StorageClass) bool {
+	if sc.Annotations == nil {
+		return false
+	}
+	return sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" ||
+		sc.Annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true"
 }
 
 func createNSResizeCluster(ctx context.Context, client klient.Client, ns string) error {

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -51,7 +51,7 @@ const helmChart = "charts/marklogic-operator-kubernetes"
 // watchedNamespaces is the comma-separated list of namespaces the operator watches.
 // Every test namespace in this suite must appear here — the namespace-scoped operator
 // only has a Role/RoleBinding in these namespaces (no ClusterRole backstop).
-const watchedNamespaces = "ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log"
+const watchedNamespaces = "ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log,ml-ns-resize-a,ml-ns-resize-b"
 
 var (
 	testEnv        env.Environment

--- a/test/e2e/1_operator_ready_test.go
+++ b/test/e2e/1_operator_ready_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestOperatorReady(t *testing.T) {
+	trackTest(t)
 	podCreationSig := make(chan *coreV1.Pod)
 
 	feature := features.New("Operator Ready")

--- a/test/e2e/2_marklogic_cluster_test.go
+++ b/test/e2e/2_marklogic_cluster_test.go
@@ -124,6 +124,7 @@ type DataSource struct {
 }
 
 func TestMarklogicCluster(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Marklogic Cluster Test").WithLabel("type", "cluster-test")
 
 	// Create dedicated test namespace

--- a/test/e2e/3_ml_cluster_ednode_test.go
+++ b/test/e2e/3_ml_cluster_ednode_test.go
@@ -74,6 +74,7 @@ var (
 )
 
 func TestMlClusterWithEdnode(t *testing.T) {
+	trackTest(t)
 	feature := features.New("MarklogicCluster Resource with 2 MarkLogicGroups (Ednode and dnode)").WithLabel("type", "ednode")
 
 	// Setup for MarklogicCluster creation

--- a/test/e2e/4_tls_test.go
+++ b/test/e2e/4_tls_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestTlsWithSelfSigned(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Self Signed Certificate").WithLabel("type", "tls-self-signed")
 	namespace := "tls-self-signed"
 	releaseName := "ml"
@@ -173,6 +174,7 @@ func TestTlsWithSelfSigned(t *testing.T) {
 }
 
 func TestTlsWithNamedCert(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Named Certificate").WithLabel("type", "tls-named-cert")
 	namespace := "marklogic-tlsnamed"
 	releaseName := "marklogic"
@@ -338,6 +340,7 @@ func TestTlsWithNamedCert(t *testing.T) {
 }
 
 func TestTlsWithMultiNode(t *testing.T) {
+	trackTest(t)
 	feature := features.New("TLS with Multi Node Named Certificate").WithLabel("type", "tls-multi-node")
 	namespace := "marklogic-tlsednode"
 	enodeName := "enode"

--- a/test/e2e/5_haproxy_test.go
+++ b/test/e2e/5_haproxy_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestHAPorxyPathBaseEnabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("HAProxy Test with Pathbased Routing Enabled").WithLabel("type", "haproxy-pathbased-enabled")
 	namespace := "haproxy-pathbased"
 	releaseName := "ml"
@@ -154,6 +155,7 @@ func TestHAPorxyPathBaseEnabled(t *testing.T) {
 }
 
 func TestHAPorxWithNoPathBasedDisabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("HAProxy Test with Pathbased Routing Disabled").WithLabel("type", "haproxy-pathbased-disabled")
 	namespace := "haproxy-test"
 	releaseName := "ml"

--- a/test/e2e/6_log_collection_test.go
+++ b/test/e2e/6_log_collection_test.go
@@ -28,6 +28,7 @@ const (
 
 // TestLogCollectionDisabled tests that fluent-bit is NOT created when LogCollection.Enabled is false
 func TestLogCollectionDisabled(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Disabled Test").WithLabel("type", "log-collection-disabled")
 
 	replicas := int32(1)
@@ -169,6 +170,7 @@ func TestLogCollectionDisabled(t *testing.T) {
 
 // TestLogCollectionPartialLogs tests selective log file collection
 func TestLogCollectionPartialLogs(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Partial Logs Test").WithLabel("type", "log-collection-partial")
 
 	replicas := int32(1)
@@ -338,6 +340,7 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 
 // TestLogCollectionCustomResources tests custom resource configuration for fluent-bit
 func TestLogCollectionCustomResources(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Custom Resources Test").WithLabel("type", "log-collection-resources")
 
 	replicas := int32(1)
@@ -521,6 +524,7 @@ func TestLogCollectionCustomResources(t *testing.T) {
 
 // TestLogCollectionCustomFilters tests custom filters configuration
 func TestLogCollectionCustomFilters(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Log Collection Custom Filters Test").WithLabel("type", "log-collection-filters")
 
 	replicas := int32(1)

--- a/test/e2e/7_istio_ambient_test.go
+++ b/test/e2e/7_istio_ambient_test.go
@@ -428,6 +428,7 @@ func waitForPodRestart(ctx context.Context, t *testing.T, c *envconf.Config, nam
 // ============================================================================
 
 func TestIstioAmbientProvisioning(t *testing.T) {
+	trackTest(t)
 	if !isIstioAmbientEnabled() {
 		t.Skip("Skipping: Istio ambient mode tests not enabled (set E2E_ISTIO_AMBIENT=true)")
 	}
@@ -647,6 +648,7 @@ func TestIstioAmbientProvisioning(t *testing.T) {
 // ============================================================================
 
 func TestIstioAmbientResilience(t *testing.T) {
+	trackTest(t)
 	if !isIstioAmbientEnabled() {
 		t.Skip("Skipping: Istio ambient mode tests not enabled (set E2E_ISTIO_AMBIENT=true)")
 	}
@@ -958,6 +960,7 @@ func TestIstioAmbientResilience(t *testing.T) {
 // ============================================================================
 
 func TestIstioAmbientNetworkGatekeeper(t *testing.T) {
+	trackTest(t)
 	if !isIstioAmbientEnabled() {
 		t.Skip("Skipping: Istio ambient mode tests not enabled (set E2E_ISTIO_AMBIENT=true)")
 	}
@@ -1124,6 +1127,7 @@ func TestIstioAmbientNetworkGatekeeper(t *testing.T) {
 // ============================================================================
 
 func TestNonIstioRegression(t *testing.T) {
+	trackTest(t)
 	if !isIstioAmbientEnabled() {
 		t.Skip("Skipping: Istio ambient mode tests not enabled (set E2E_ISTIO_AMBIENT=true)")
 	}

--- a/test/e2e/8_metrics_test.go
+++ b/test/e2e/8_metrics_test.go
@@ -51,7 +51,7 @@ const (
 //	E2E_METRICS_SECURE  "true"|"false"            (default: "true")
 //	E2E_SCOPE_TYPE      "cluster"|"namespace"     (default: "cluster")
 func TestMetricsEndpoint(t *testing.T) {
-	// ── Resolve runtime configuration ─────────────────────────────────────────
+	trackTest(t)                                                // ── Resolve runtime configuration ─────────────────────────────────────────
 	metricsSecure := os.Getenv("E2E_METRICS_SECURE") != "false" // default true
 	scopeType := os.Getenv("E2E_SCOPE_TYPE")
 	if scopeType == "" {

--- a/test/e2e/9_volume_resize_test.go
+++ b/test/e2e/9_volume_resize_test.go
@@ -66,6 +66,7 @@ type resizeOutcome struct {
 // TestVolumeResizeClusterScoped resizes PVCs in two namespaces concurrently
 // against the cluster-scoped operator and prints a clear pass/fail summary.
 func TestVolumeResizeClusterScoped(t *testing.T) {
+	trackTest(t)
 	feature := features.New("Volume Resize — Cluster-Scoped, Multi-Namespace").
 		WithLabel("type", "volume-resize")
 

--- a/test/e2e/9_volume_resize_test.go
+++ b/test/e2e/9_volume_resize_test.go
@@ -175,20 +175,48 @@ func TestVolumeResizeClusterScoped(t *testing.T) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// assertDefaultStorageClassExpandable returns nil if at least one StorageClass
-// in the cluster has allowVolumeExpansion=true. The test relies on the default
-// SC being expandable (the case for minikube's `standard` provisioner).
+// assertDefaultStorageClassExpandable returns nil only if the cluster's
+// **default** StorageClass exists and has allowVolumeExpansion=true. The
+// resize-test MarklogicCluster does not set spec.persistence.storageClassName,
+// so PVCs are bound through the default SC; checking any random expandable SC
+// would let the test proceed and then fail later during actual resize.
 func assertDefaultStorageClassExpandable(ctx context.Context, client klient.Client) error {
 	scList := &storagev1.StorageClassList{}
 	if err := client.Resources().List(ctx, scList); err != nil {
 		return fmt.Errorf("list StorageClasses: %w", err)
 	}
+	var defaults []storagev1.StorageClass
 	for _, sc := range scList.Items {
-		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
-			return nil
+		if isDefaultStorageClass(sc) {
+			defaults = append(defaults, sc)
 		}
 	}
-	return fmt.Errorf("no StorageClass with allowVolumeExpansion=true found; volume resize cannot be tested")
+	switch len(defaults) {
+	case 0:
+		return fmt.Errorf("no default StorageClass found (annotation storageclass.kubernetes.io/is-default-class=true); volume resize cannot be tested")
+	case 1:
+		sc := defaults[0]
+		if sc.AllowVolumeExpansion == nil || !*sc.AllowVolumeExpansion {
+			return fmt.Errorf("default StorageClass %q has allowVolumeExpansion=false; volume resize cannot succeed", sc.Name)
+		}
+		return nil
+	default:
+		names := make([]string, 0, len(defaults))
+		for _, sc := range defaults {
+			names = append(names, sc.Name)
+		}
+		return fmt.Errorf("multiple default StorageClasses found (%s); cannot determine which one PVCs will bind to", strings.Join(names, ", "))
+	}
+}
+
+// isDefaultStorageClass reports whether sc carries either the GA or the legacy
+// beta default-class annotation set to "true".
+func isDefaultStorageClass(sc storagev1.StorageClass) bool {
+	if sc.Annotations == nil {
+		return false
+	}
+	return sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" ||
+		sc.Annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true"
 }
 
 // createResizeNamespaceAndCluster creates the namespace and a MarklogicCluster

--- a/test/e2e/9_volume_resize_test.go
+++ b/test/e2e/9_volume_resize_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2e
+
+// Volume Resize – Cluster-Scoped E2E Test
+//
+// This test exercises the operator's volume-resizing feature against the
+// cluster-scoped operator deployed by `make deploy` in TestMain.
+//
+// Two MarklogicCluster instances are created in TWO DIFFERENT NAMESPACES at
+// the same time (one in ml-resize-a, one in ml-resize-b) and resized in
+// parallel. This validates that the cluster-scoped operator can reconcile
+// resize operations concurrently across namespaces.
+//
+// Result summary:
+// At the end of the test a banner is printed for each namespace with
+// PASS/FAIL plus the initial / requested / observed PVC capacity, so the
+// outcome is easy to read at a glance in CI logs.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	frameworkutils "sigs.k8s.io/e2e-framework/pkg/utils"
+)
+
+// resizeNamespaces are the two parallel test namespaces. They must NOT collide
+// with any other test namespace in this package.
+var resizeNamespaces = []string{"ml-resize-a", "ml-resize-b"}
+
+const (
+	resizeClusterName = "ml-resize-cluster"
+	resizeGroupName   = "node"
+	resizeInitialSize = "2Gi"
+	resizeTargetSize  = "3Gi"
+	resizeWaitTimeout = 15 * time.Minute
+)
+
+// resizeOutcome captures the per-namespace result for the final summary banner.
+type resizeOutcome struct {
+	namespace    string
+	initialSize  string
+	requestSize  string
+	observedSize string
+	phase        string
+	passed       bool
+	failReason   string
+}
+
+// TestVolumeResizeClusterScoped resizes PVCs in two namespaces concurrently
+// against the cluster-scoped operator and prints a clear pass/fail summary.
+func TestVolumeResizeClusterScoped(t *testing.T) {
+	feature := features.New("Volume Resize — Cluster-Scoped, Multi-Namespace").
+		WithLabel("type", "volume-resize")
+
+	// ── Pre-flight: storage class must allow expansion ────────────────────────
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if err := assertDefaultStorageClassExpandable(ctx, c.Client()); err != nil {
+			t.Fatalf("Pre-flight failed: %v", err)
+		}
+		return ctx
+	})
+
+	// ── Create both namespaces and both clusters in parallel ──────────────────
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		marklogicv1.AddToScheme(client.Resources().GetScheme())
+
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(resizeNamespaces))
+		for _, ns := range resizeNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := createResizeNamespaceAndCluster(ctx, t, client, ns); err != nil {
+					errCh <- fmt.Errorf("[%s] %w", ns, err)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Fatalf("Setup failed: %v", err)
+		}
+		return ctx
+	})
+
+	// ── Wait for node-0 in BOTH namespaces in parallel ────────────────────────
+	feature.Assess("MarkLogic pods Ready in both namespaces", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(resizeNamespaces))
+		for _, ns := range resizeNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := utils.WaitForPod(ctx, t, client, ns, "node-0", 5*time.Minute, true); err != nil {
+					errCh <- fmt.Errorf("[%s] node-0 not ready: %w", ns, err)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.Fatalf("%v", err)
+		}
+		return ctx
+	})
+
+	// ── Trigger resize and verify outcome in parallel ─────────────────────────
+	feature.Assess("PVCs resized to target size in both namespaces", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+
+		var (
+			wg       sync.WaitGroup
+			mu       sync.Mutex
+			outcomes = make([]resizeOutcome, 0, len(resizeNamespaces))
+		)
+		for _, ns := range resizeNamespaces {
+			ns := ns
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				out := triggerAndWaitForResize(ctx, t, client, ns)
+				mu.Lock()
+				outcomes = append(outcomes, out)
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		printResizeSummary(t, "Volume Resize — Cluster-Scoped", outcomes)
+
+		for _, o := range outcomes {
+			if !o.passed {
+				dumpResizeDiagnostics(t, o.namespace)
+				t.Errorf("[%s] resize did NOT complete: %s", o.namespace, o.failReason)
+			}
+		}
+		return ctx
+	})
+
+	// ── Teardown: delete both namespaces (drops cluster + PVCs) ───────────────
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		for _, ns := range resizeNamespaces {
+			nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+			if err := client.Resources().Delete(ctx, nsObj); err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("Warning: failed to delete namespace %s: %v", ns, err)
+			}
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// assertDefaultStorageClassExpandable returns nil if at least one StorageClass
+// in the cluster has allowVolumeExpansion=true. The test relies on the default
+// SC being expandable (the case for minikube's `standard` provisioner).
+func assertDefaultStorageClassExpandable(ctx context.Context, client klient.Client) error {
+	scList := &storagev1.StorageClassList{}
+	if err := client.Resources().List(ctx, scList); err != nil {
+		return fmt.Errorf("list StorageClasses: %w", err)
+	}
+	for _, sc := range scList.Items {
+		if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
+			return nil
+		}
+	}
+	return fmt.Errorf("no StorageClass with allowVolumeExpansion=true found; volume resize cannot be tested")
+}
+
+// createResizeNamespaceAndCluster creates the namespace and a MarklogicCluster
+// with persistence size = resizeInitialSize.
+func createResizeNamespaceAndCluster(ctx context.Context, t *testing.T, client klient.Client, ns string) error {
+	t.Logf("[%s] creating namespace + MarklogicCluster (size=%s)", ns, resizeInitialSize)
+
+	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: namespaceLabels()}}
+	if err := client.Resources().Create(ctx, nsObj); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace: %w", err)
+	}
+
+	r := int32(1)
+	cluster := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: resizeClusterName, Namespace: ns},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUsername,
+				AdminPassword: &adminPassword,
+			},
+			Persistence: &marklogicv1.Persistence{
+				Enabled: true,
+				Size:    resizeInitialSize,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        resizeGroupName,
+					Replicas:    &r,
+					IsBootstrap: true,
+				},
+			},
+		},
+	}
+	if err := client.Resources(ns).Create(ctx, cluster); err != nil {
+		return fmt.Errorf("create MarklogicCluster: %w", err)
+	}
+	return nil
+}
+
+// triggerAndWaitForResize patches the cluster persistence size to the target
+// value and polls until either the MarklogicGroup VolumeResizeStatus reports
+// Completed (and the PVC capacity matches) or the timeout elapses.
+func triggerAndWaitForResize(ctx context.Context, t *testing.T, client klient.Client, ns string) resizeOutcome {
+	out := resizeOutcome{namespace: ns, initialSize: resizeInitialSize, requestSize: resizeTargetSize}
+
+	// Capture the current PVC capacity for the per-namespace summary.
+	if size, err := minPVCCapacity(ctx, client, ns); err == nil {
+		out.initialSize = size
+	}
+
+	// Patch spec.persistence.size on the MarklogicCluster (triggers reconcile).
+	patch := []byte(fmt.Sprintf(`{"spec":{"persistence":{"size":"%s"}}}`, resizeTargetSize))
+	cluster := &marklogicv1.MarklogicCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: resizeClusterName, Namespace: ns},
+	}
+	if err := client.Resources(ns).Patch(ctx, cluster, k8s.Patch{PatchType: types.MergePatchType, Data: patch}); err != nil {
+		out.failReason = fmt.Sprintf("patch cluster: %v", err)
+		return out
+	}
+	t.Logf("[%s] patched MarklogicCluster persistence.size → %s", ns, resizeTargetSize)
+
+	// Poll until Completed or timeout.
+	deadline := time.Now().Add(resizeWaitTimeout)
+	for time.Now().Before(deadline) {
+		grp := &marklogicv1.MarklogicGroup{}
+		if err := client.Resources(ns).Get(ctx, resizeGroupName, ns, grp); err != nil {
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		if grp.Status.VolumeResizeStatus != nil {
+			out.phase = string(grp.Status.VolumeResizeStatus.Phase)
+		}
+		obs, _ := minPVCCapacity(ctx, client, ns)
+		out.observedSize = obs
+
+		// Success criteria: phase=Completed AND every PVC reaches the target.
+		if out.phase == string(marklogicv1.VolumeResizePhaseCompleted) && sizesEqual(obs, resizeTargetSize) {
+			out.passed = true
+			return out
+		}
+		// Hard-fail criteria: phase=Failed.
+		if out.phase == string(marklogicv1.VolumeResizePhaseFailed) {
+			out.failReason = fmt.Sprintf("phase=Failed reason=%s msg=%s",
+				grp.Status.VolumeResizeStatus.Reason, grp.Status.VolumeResizeStatus.Message)
+			return out
+		}
+		t.Logf("[%s] resize in progress: phase=%s observed=%s target=%s", ns, out.phase, obs, resizeTargetSize)
+		time.Sleep(15 * time.Second)
+	}
+	out.failReason = fmt.Sprintf("timeout after %s (last phase=%s observed=%s)", resizeWaitTimeout, out.phase, out.observedSize)
+	return out
+}
+
+// minPVCCapacity returns the smallest .status.capacity.storage across the PVCs
+// owned by the resize StatefulSet in ns, formatted as a human-readable string.
+func minPVCCapacity(ctx context.Context, client klient.Client, ns string) (string, error) {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := client.Resources(ns).List(ctx, pvcs); err != nil {
+		return "", err
+	}
+	var min *resource.Quantity
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		// Restrict to PVCs whose name belongs to the resize StatefulSet.
+		if !strings.HasPrefix(pvc.Name, "datadir-"+resizeGroupName+"-") {
+			continue
+		}
+		q, ok := pvc.Status.Capacity[corev1.ResourceStorage]
+		if !ok {
+			continue
+		}
+		if min == nil || q.Cmp(*min) < 0 {
+			qq := q.DeepCopy()
+			min = &qq
+		}
+	}
+	if min == nil {
+		return "", fmt.Errorf("no PVC capacity reported yet")
+	}
+	return min.String(), nil
+}
+
+// sizesEqual compares two storage size strings (e.g. "3Gi" == "3072Mi").
+func sizesEqual(a, b string) bool {
+	qa, errA := resource.ParseQuantity(a)
+	qb, errB := resource.ParseQuantity(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return qa.Cmp(qb) == 0
+}
+
+// dumpResizeDiagnostics prints, for a failing namespace, the resources most
+// likely to explain why the resize did not complete: PVCs, the StatefulSet,
+// the MarklogicCluster + MarklogicGroup CRs, recent Kubernetes events in the
+// namespace, and the last 200 lines of the operator pod logs.
+func dumpResizeDiagnostics(t *testing.T, ns string) {
+	t.Helper()
+	line := strings.Repeat("-", 78)
+	t.Logf("\n%s\n  DIAGNOSTICS for namespace %s\n%s", line, ns, line)
+	for _, cmd := range []string{
+		fmt.Sprintf("kubectl get pvc -n %s -o wide", ns),
+		fmt.Sprintf("kubectl describe pvc -n %s", ns),
+		fmt.Sprintf("kubectl get statefulset -n %s -o wide", ns),
+		fmt.Sprintf("kubectl get pods -n %s -o wide", ns),
+		fmt.Sprintf("kubectl get marklogiccluster,marklogicgroup -n %s -o yaml", ns),
+		fmt.Sprintf("kubectl get events -n %s --sort-by=.lastTimestamp", ns),
+	} {
+		p := frameworkutils.RunCommand(cmd)
+		t.Logf("$ %s\n%s", cmd, p.Result())
+	}
+	p := frameworkutils.RunCommand(
+		fmt.Sprintf("kubectl logs -n %s -l control-plane=controller-manager --tail=200 --prefix=true", namespace),
+	)
+	t.Logf("Operator logs (last 200 lines):\n%s", p.Result())
+	t.Logf("%s\n", line)
+}
+
+// printResizeSummary prints an easy-to-read banner describing each namespace's
+// outcome. Designed to stand out in CI log scrollback.
+func printResizeSummary(t *testing.T, title string, outcomes []resizeOutcome) {
+	t.Helper()
+	line := strings.Repeat("=", 78)
+	t.Logf("\n%s\n  %s — RESULT SUMMARY\n%s", line, title, line)
+	for _, o := range outcomes {
+		status := "✅ PASS"
+		if !o.passed {
+			status = "❌ FAIL"
+		}
+		t.Logf("  [%-12s] %s  initial=%-6s  requested=%-6s  observed=%-6s  phase=%s",
+			o.namespace, status, o.initialSize, o.requestSize, o.observedSize, o.phase)
+		if !o.passed && o.failReason != "" {
+			t.Logf("                    reason: %s", o.failReason)
+		}
+	}
+	t.Logf("%s\n", line)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,6 +48,68 @@ func namespaceLabels() map[string]string {
 		}
 	}
 	return nil
+}
+
+// ── Test summary tracker ──────────────────────────────────────────────────────
+
+type testResult struct {
+	name   string
+	passed bool
+}
+
+var (
+	trackMu      sync.Mutex
+	trackedTests []testResult
+)
+
+// trackTest registers t in the global summary. Call it at the top of each Test* function.
+// t.Cleanup runs after the test (and all its sub-tests) complete, so t.Failed() is final.
+func trackTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		trackMu.Lock()
+		trackedTests = append(trackedTests, testResult{name: t.Name(), passed: !t.Failed()})
+		trackMu.Unlock()
+	})
+}
+
+// printTestSummary logs a structured pass/fail banner of all tracked tests to stdout.
+func printTestSummary() {
+	trackMu.Lock()
+	results := make([]testResult, len(trackedTests))
+	copy(results, trackedTests)
+	trackMu.Unlock()
+
+	total := len(results)
+	passed := 0
+	var failed []string
+	for _, r := range results {
+		if r.passed {
+			passed++
+		} else {
+			failed = append(failed, r.name)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║              E2E (CLUSTER-SCOPED) TEST SUITE SUMMARY         ║")
+	fmt.Println("╠══════════════════════════════════════════════════════════════╣")
+	fmt.Printf("║  Total  : %-51d║\n", total)
+	fmt.Printf("║  Passed : %-51d║\n", passed)
+	fmt.Printf("║  Failed : %-51d║\n", len(failed))
+	if len(failed) > 0 {
+		fmt.Println("╠══════════════════════════════════════════════════════════════╣")
+		fmt.Println("║  Failed tests:                                               ║")
+		for _, name := range failed {
+			if len(name) > 49 {
+				name = name[:46] + "..."
+			}
+			fmt.Printf("║    ✗ %-57s║\n", name)
+		}
+	}
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
 }
 
 func TestMain(m *testing.M) {
@@ -258,5 +321,7 @@ func TestMain(m *testing.M) {
 	)
 
 	// Use Environment.Run to launch the test
-	os.Exit(testEnv.Run(m))
+	exitCode := testEnv.Run(m)
+	printTestSummary()
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
This pull request introduces parallel volume resize end-to-end (e2e) tests for both cluster-scoped and Helm namespace-scoped operator deployments, and integrates them into the CI pipeline. The changes ensure that PersistentVolumeClaim (PVC) resizing is tested concurrently in two namespaces, improving coverage and reliability of the operator's volume expansion features.

**E2E Test Additions and Improvements:**

* Added a new test `TestVolumeResizeNamespaceScoped` in `test/e2e-helm/9_volume_resize_test.go` that validates PVC resizing in two watched namespaces in parallel for Helm-installed, namespace-scoped operators. The test includes clear pass/fail summaries and diagnostics on failure.
* Updated the `watchedNamespaces` constant in `test/e2e-helm/main_test.go` to include the two new namespaces (`ml-ns-resize-a`, `ml-ns-resize-b`) required for the volume resize tests.

**Makefile and Pipeline Integration:**

* Added `e2e-test-volume-resize` and `e2e-test-helm-volume-resize` targets to the `Makefile` to run the new cluster-scoped and Helm namespace-scoped volume resize tests, respectively.
* Added `runVolumeResizeE2eTests` and `runHelmVolumeResizeE2eTests` helper functions to the `Jenkinsfile` to invoke these new Makefile targets.

**CI Pipeline Enhancements:**

* Introduced a new `VERIFY_VOLUME_RESIZE` pipeline parameter (default: true) to enable or disable the volume resize e2e tests in the Jenkins pipeline.
* Added new pipeline stages in the `Jenkinsfile` to set up Minikube, run both volume resize tests, and perform cleanup, all gated by the `VERIFY_VOLUME_RESIZE` parameter.