### PR TITLE
MLE-29504 remove MarkLogic image from BlackDuck scan

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ void runBlackDuckScan() {
     if (!haProxyImage)   { error "runBlackDuckScan: could not resolve HAProxy image from Makefile" }
     if (!ubi9Image)      { error "runBlackDuckScan: could not resolve UBI9 image from pkg/k8sutil/statefulset.go" }
 
-    def dependentImages = "${fluentBitImage},${haProxyImage},${ubi9Image},${params.E2E_MARKLOGIC_IMAGE_VERSION}"
+    def dependentImages = "${fluentBitImage},${haProxyImage},${ubi9Image}"
 
     def containerImages
     if (params.PUBLISH_IMAGE) {


### PR DESCRIPTION
MarkLogic server images are getting scanned as part of Docker pipeline and don't need to be scanned and analyzed again in the operator pipeline.