### PR TITLE
MLE-29602: Upgrade redhat/ubi9 base image from 9.4 to 9.7 in copy-certs init container

### DIFF
--- a/api/v1/marklogiccluster_types.go
+++ b/api/v1/marklogiccluster_types.go
@@ -27,7 +27,7 @@ import (
 
 // MarklogicClusterSpec defines the desired state of MarklogicCluster
 
-// +kubebuilder:validation:XValidation:rule="!(self.haproxy.enabled == true && self.haproxy.pathBasedRouting == true) || self.image.split(':')[1].matches('.*latest.*') || int(self.image.split(':')[1].split('.')[0] + self.image.split(':')[1].split('.')[1]) >= 111", message="HAProxy and Pathbased Routing is enabled. PathBasedRouting is only supported for MarkLogic 11.1 and above"
+// +kubebuilder:validation:XValidation:rule="!has(self.haproxy) || !(self.haproxy.enabled == true && self.haproxy.pathBasedRouting == true) || self.image.split(':')[1].matches('.*latest.*') || int(self.image.split(':')[1].split('.')[0] + self.image.split(':')[1].split('.')[1]) >= 111", message="HAProxy and Pathbased Routing is enabled. PathBasedRouting is only supported for MarkLogic 11.1 and above"
 type MarklogicClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file

--- a/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
+++ b/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
@@ -10033,7 +10033,7 @@ spec:
             x-kubernetes-validations:
             - message: HAProxy and Pathbased Routing is enabled. PathBasedRouting
                 is only supported for MarkLogic 11.1 and above
-              rule: '!(self.haproxy.enabled == true && self.haproxy.pathBasedRouting
+              rule: '!has(self.haproxy) || !(self.haproxy.enabled == true && self.haproxy.pathBasedRouting
                 == true) || self.image.split('':'')[1].matches(''.*latest.*'') ||
                 int(self.image.split('':'')[1].split(''.'')[0] + self.image.split('':'')[1].split(''.'')[1])
                 >= 111'

--- a/pkg/k8sutil/scripts/copy-certs.sh
+++ b/pkg/k8sutil/scripts/copy-certs.sh
@@ -20,7 +20,7 @@ if [[ "$certType" == "named" ]]; then
     cp -f /tmp/ca-cert-secret/* /run/secrets/marklogic-certs/;
     cert_paths=$(find /tmp/server-cert-secrets/tls_*.crt)
     for cert_path in $cert_paths; do
-    cert_cn=$(openssl x509 -noout -subject -in $cert_path | sed -n 's/.*CN = \([^,]*\).*/\1/p')
+    cert_cn=$(openssl x509 -noout -subject -nameopt multiline -in $cert_path | grep 'commonName' | sed 's/.*= *//')
     log "Info: [copy-certs] FQDN for the certificate: $cert_cn"
     if [[ "$host_FQDN" == "$cert_cn" ]]; then
         log "Info: [copy-certs] found certificate for the server"

--- a/pkg/k8sutil/statefulset.go
+++ b/pkg/k8sutil/statefulset.go
@@ -276,7 +276,7 @@ func generateStatefulSetsDef(stsMeta metav1.ObjectMeta, params statefulSetParame
 		statefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{
 			{
 				Name:            "copy-certs",
-				Image:           "redhat/ubi9:9.4",
+				Image:           "redhat/ubi9:9.7",
 				ImagePullPolicy: "IfNotPresent",
 				Command:         []string{"/bin/sh", "/tmp/helm-scripts/copy-certs.sh"},
 				VolumeMounts:    copyCertsVM,


### PR DESCRIPTION
## MLE-29602: Upgrade redhat/ubi9 base image from 9.4 to 9.7 in copy-certs init container

**Jira:** https://progresssoftware.atlassian.net/browse/MLE-29602

### Changes

**1. `pkg/k8sutil/statefulset.go`** — upgrade `copy-certs` init container image from `redhat/ubi9:9.4` to `redhat/ubi9:9.7`. The Jenkinsfile reads this value dynamically via grep, so it picks up the new version automatically.

**2. `pkg/k8sutil/scripts/copy-certs.sh`** — fix CN extraction to be compatible with OpenSSL in ubi9:9.7.

ubi9:9.7 ships a version of OpenSSL that changed the `subject` output format:
- **Before (ubi9:9.4):** `subject=CN = hostname, ...`
- **After (ubi9:9.7):** `subject=CN=hostname, ...` *(no spaces around `=`)*

The original `sed -n 's/.*CN = \([^,]*\).*/\1/p'` produced an empty string with the new format, causing the init container to fail with:
```
FQDN for the certificate:
Error: [copy-certs] Failed to find matching certificate for the bootstrap server. Exiting.
```

Fix replaces the `sed` pattern with `openssl -nameopt multiline` output which provides a stable, version-agnostic structured format:
```bash
# Before
cert_cn=$(openssl x509 -noout -subject -in $cert_path | sed -n 's/.*CN = \([^,]*\).*/\1/p')
# After
cert_cn=$(openssl x509 -noout -subject -nameopt multiline -in $cert_path | grep 'commonName' | sed 's/.*= *//')
```

**3. `api/v1/marklogiccluster_types.go` + `config/crd/bases/marklogic.progress.com_marklogicclusters.yaml`** — fix CEL validation rule to guard optional `haproxy` field with `has()`.

Kubernetes 1.31 strictly enforces CEL presence checks for optional struct fields. The existing rule accessed `self.haproxy.enabled` without first checking `has(self.haproxy)`, causing all TLS test clusters (which omit `haproxy`) to be rejected with:
```
no such key: haproxy
```

Fix adds `!has(self.haproxy) ||` as a short-circuit prefix so the rule trivially passes when HAProxy is not configured.

### Validation

- `make test` (unit tests): 5 passed, 0 failed
- Local e2e on minikube (Kubernetes v1.31.13):
  - `TestTlsWithNamedCert` — **PASSED**
  - `TestTlsWithMultiNode` — **PASSED**