### PR TITLE
MLE-29900: Fix Dynamic Host E2E test

### DIFF
--- a/pkg/k8sutil/dynamic_reconcile.go
+++ b/pkg/k8sutil/dynamic_reconcile.go
@@ -1716,6 +1716,14 @@ func (oc *OperatorContext) resolveDynamicClusterNameCandidates(groupClient mlman
 		candidates = append(candidates, candidate)
 	}
 
+	// ResolveClusterName (GET /manage/v2) returns the actual cluster name from the
+	// version envelope "name" field and is more authoritative than ResolveClusterNameCandidates
+	// (GET /manage/v2/clusters), which may return API-format envelope keys. Add it first
+	// so callers try the authoritative name before falling back to list candidates.
+	if resolvedClusterName, err := groupClient.ResolveClusterName(oc.Ctx); err == nil {
+		addCandidate(resolvedClusterName)
+	}
+
 	if resolver, ok := groupClient.(interface {
 		ResolveClusterNameCandidates(context.Context) ([]string, error)
 	}); ok {
@@ -1724,13 +1732,6 @@ func (oc *OperatorContext) resolveDynamicClusterNameCandidates(groupClient mlman
 				addCandidate(candidate)
 			}
 		}
-	}
-
-	// Always supplement with the ResolveClusterName result. The /manage/v2/clusters
-	// endpoint may return API-format keys (e.g. "local-cluster-default") that differ
-	// from the actual MarkLogic cluster name. The /manage/v2 path is more authoritative.
-	if resolvedClusterName, err := groupClient.ResolveClusterName(oc.Ctx); err == nil {
-		addCandidate(resolvedClusterName)
 	}
 
 	return candidates

--- a/pkg/k8sutil/dynamic_reconcile.go
+++ b/pkg/k8sutil/dynamic_reconcile.go
@@ -1726,10 +1726,11 @@ func (oc *OperatorContext) resolveDynamicClusterNameCandidates(groupClient mlman
 		}
 	}
 
-	if len(candidates) == 0 {
-		if resolvedClusterName, err := groupClient.ResolveClusterName(oc.Ctx); err == nil {
-			addCandidate(resolvedClusterName)
-		}
+	// Always supplement with the ResolveClusterName result. The /manage/v2/clusters
+	// endpoint may return API-format keys (e.g. "local-cluster-default") that differ
+	// from the actual MarkLogic cluster name. The /manage/v2 path is more authoritative.
+	if resolvedClusterName, err := groupClient.ResolveClusterName(oc.Ctx); err == nil {
+		addCandidate(resolvedClusterName)
 	}
 
 	return candidates

--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -1019,6 +1019,9 @@ func extractClusterNameCandidatesFromClusterList(payload any) []string {
 		_, hasVersion := child["version"]
 		_, hasEffectiveVersion := child["effective-version"]
 		if hasVersion || hasEffectiveVersion {
+			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref")); innerName != "" {
+				addCandidate(innerName)
+			}
 			addCandidate(key)
 		}
 	}
@@ -1063,6 +1066,10 @@ func findClusterNameByVersionEnvelope(node map[string]any) string {
 		_, hasVersion := child["version"]
 		_, hasEffectiveVersion := child["effective-version"]
 		if hasVersion || hasEffectiveVersion {
+			// Prefer inner cluster-name/nameref over the API envelope key.
+			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref")); innerName != "" {
+				return innerName
+			}
 			return key
 		}
 	}

--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -1019,7 +1019,10 @@ func extractClusterNameCandidatesFromClusterList(payload any) []string {
 		_, hasVersion := child["version"]
 		_, hasEffectiveVersion := child["effective-version"]
 		if hasVersion || hasEffectiveVersion {
-			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref")); innerName != "" {
+			// "name" is the actual MarkLogic cluster name in the version envelope
+			// (e.g. GET /manage/v2 returns {"local-cluster-default":{"name":"...-cluster",...}}).
+			// Prefer it over the API-format envelope key.
+			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref", "name")); innerName != "" {
 				addCandidate(innerName)
 			}
 			addCandidate(key)
@@ -1066,8 +1069,10 @@ func findClusterNameByVersionEnvelope(node map[string]any) string {
 		_, hasVersion := child["version"]
 		_, hasEffectiveVersion := child["effective-version"]
 		if hasVersion || hasEffectiveVersion {
-			// Prefer inner cluster-name/nameref over the API envelope key.
-			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref")); innerName != "" {
+			// "name" is the actual MarkLogic cluster name in the version envelope
+			// (e.g. GET /manage/v2 returns {"local-cluster-default":{"name":"...-cluster",...}}).
+			// Prefer it over the API-format envelope key.
+			if innerName := strings.TrimSpace(firstString(child, "cluster-name", "nameref", "name")); innerName != "" {
 				return innerName
 			}
 			return key

--- a/pkg/mlmanage/client_test.go
+++ b/pkg/mlmanage/client_test.go
@@ -346,6 +346,66 @@ func TestResolveClusterNameCandidatesFromClusterListIncludesIdrefAndNameref(t *t
 	}
 }
 
+// TestResolveClusterNameCandidatesVersionEnvelopePreservesInnerNameOrder verifies that
+// when /manage/v2/clusters returns a version-envelope response (MarkLogic 12 format),
+// the inner "name" field is listed before the raw envelope key in the candidate slice,
+// ensuring callers try the authoritative cluster name first.
+func TestResolveClusterNameCandidatesVersionEnvelopePreservesInnerNameOrder(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manage/v2/clusters":
+			w.WriteHeader(http.StatusOK)
+			// MarkLogic 12 version-envelope response from GET /manage/v2/clusters:
+			// the envelope key is "local-cluster-default"; the actual cluster name
+			// is in the nested "name" field.
+			_, _ = w.Write([]byte(`{"local-cluster-default":{"id":"7743706418977919939","name":"node-0.node.ml-dynamic-host.svc.cluster.local-cluster","version":"12.0.1","effective-version":12000001}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &managementClient{
+		baseURL:    server.URL,
+		username:   "user",
+		password:   "password",
+		httpClient: server.Client(),
+	}
+
+	candidates, err := client.ResolveClusterNameCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveClusterNameCandidates returned error: %v", err)
+	}
+
+	// The inner "name" must appear before the raw envelope key.
+	innerName := "node-0.node.ml-dynamic-host.svc.cluster.local-cluster"
+	envelopeKey := "local-cluster-default"
+
+	innerIdx := -1
+	envelopeIdx := -1
+	for i, c := range candidates {
+		if c == innerName {
+			innerIdx = i
+		}
+		if c == envelopeKey {
+			envelopeIdx = i
+		}
+	}
+
+	if innerIdx == -1 {
+		t.Fatalf("expected candidate %q to be present, got %v", innerName, candidates)
+	}
+	if envelopeIdx == -1 {
+		t.Fatalf("expected candidate %q to be present, got %v", envelopeKey, candidates)
+	}
+	if innerIdx >= envelopeIdx {
+		t.Fatalf("expected inner name %q (idx %d) to appear before envelope key %q (idx %d) in %v",
+			innerName, innerIdx, envelopeKey, envelopeIdx, candidates)
+	}
+}
+
 func TestListHostsStatusParsesHostStatusListEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mlmanage/client_test.go
+++ b/pkg/mlmanage/client_test.go
@@ -217,7 +217,9 @@ func TestResolveClusterNameParsesVersionEnvelopeKey(t *testing.T) {
 			_, _ = w.Write([]byte(`{"errorResponse":{"message":"not found"}}`))
 		case "/manage/v2":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"local-cluster-default":{"version":"12.0.0","effective-version":12000000}}`))
+			// MarkLogic 12 version envelope: envelope key is "local-cluster-{x}",
+			// actual cluster name is in the "name" field.
+			_, _ = w.Write([]byte(`{"local-cluster-default":{"id":"7743706418977919939","name":"node-0.node.ml-dynamic-host.svc.cluster.local-cluster","version":"12.0.1","effective-version":12000001}}`))
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -235,8 +237,9 @@ func TestResolveClusterNameParsesVersionEnvelopeKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveClusterName returned error: %v", err)
 	}
-	if clusterName != "local-cluster-default" {
-		t.Fatalf("expected cluster name local-cluster-default, got %s", clusterName)
+	// The "name" field inside the version envelope is the actual MarkLogic cluster name.
+	if clusterName != "node-0.node.ml-dynamic-host.svc.cluster.local-cluster" {
+		t.Fatalf("expected cluster name from 'name' field in version envelope, got %s", clusterName)
 	}
 }
 

--- a/test/e2e/10_dynamic_host_test.go
+++ b/test/e2e/10_dynamic_host_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"testing"
@@ -727,7 +728,7 @@ func removeDynamicHostByID(t *testing.T, hostID string) error {
 		payload,
 		adminUsername,
 		adminPassword,
-		clusterName,
+		url.PathEscape(clusterName),
 	)
 	out, err := utils.ExecCmdInPod(dynamicBootstrapPodName(), dynamicE2ENamespace, dynamicE2EMLContainerName, cmd)
 	if err != nil {

--- a/test/e2e/10_dynamic_host_test.go
+++ b/test/e2e/10_dynamic_host_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -680,15 +681,53 @@ func assertAllowDynamicHostsEnabled(t *testing.T) {
 	}
 }
 
+// fetchMLClusterName queries GET /manage/v2 on the bootstrap pod and returns the
+// actual MarkLogic cluster name (the "name" field inside the version envelope).
+// Example response: {"local-cluster-default":{"id":"...","name":"node-0.node.ml-dynamic-host.svc.cluster.local-cluster",...}}
+// Falls back to the K8s resource name if the query or parse fails.
+func fetchMLClusterName(t *testing.T) string {
+	t.Helper()
+	cmd := fmt.Sprintf(
+		"curl -sS --digest -u '%s:%s' 'http://localhost:8002/manage/v2?format=json'",
+		adminUsername,
+		adminPassword,
+	)
+	out, err := utils.ExecCmdInPod(dynamicBootstrapPodName(), dynamicE2ENamespace, dynamicE2EMLContainerName, cmd)
+	if err != nil {
+		t.Logf("warning: failed to query ML cluster name, using K8s resource name %q: %v", dynamicE2EClusterName, err)
+		return dynamicE2EClusterName
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Logf("warning: failed to parse /manage/v2 response, using K8s resource name %q: %v", dynamicE2EClusterName, err)
+		return dynamicE2EClusterName
+	}
+	for key, raw := range envelope {
+		if strings.EqualFold(key, "errorResponse") {
+			continue
+		}
+		var inner struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &inner); err == nil && inner.Name != "" {
+			t.Logf("resolved ML cluster name %q from /manage/v2", inner.Name)
+			return inner.Name
+		}
+	}
+	t.Logf("warning: no cluster name found in /manage/v2 response, using K8s resource name %q", dynamicE2EClusterName)
+	return dynamicE2EClusterName
+}
+
 func removeDynamicHostByID(t *testing.T, hostID string) error {
 	t.Helper()
+	clusterName := fetchMLClusterName(t)
 	payload := fmt.Sprintf("<dynamic-hosts><dynamic-host>%s</dynamic-host></dynamic-hosts>", hostID)
 	cmd := fmt.Sprintf(
 		"payload='%s'; status=$(curl -sS -o /tmp/dh-remove.out -w '%%{http_code}' --digest -u '%s:%s' -H 'Content-Type: application/xml' -X DELETE --data \"$payload\" 'http://localhost:8002/manage/v2/clusters/%s/dynamic-hosts'); echo \"HTTP_STATUS=$status\"; cat /tmp/dh-remove.out",
 		payload,
 		adminUsername,
 		adminPassword,
-		dynamicE2EClusterName,
+		clusterName,
 	)
 	out, err := utils.ExecCmdInPod(dynamicBootstrapPodName(), dynamicE2ENamespace, dynamicE2EMLContainerName, cmd)
 	if err != nil {


### PR DESCRIPTION
This pull request improves the reliability of cluster name detection by ensuring that the actual MarkLogic cluster name is preferred over API-format keys when extracting cluster names from management API responses. The changes ensure that the more authoritative cluster name is always included and prioritized when available.

**Improvements to cluster name extraction:**

* When extracting cluster name candidates from the `/manage/v2/clusters` API response, the code now always supplements the candidate list with the result from the more authoritative `ResolveClusterName` method, ensuring the actual MarkLogic cluster name is included even if the API returns a different format.
* When parsing cluster lists, the extraction logic now prefers the inner `cluster-name` or `nameref` field (if present and non-empty) over the envelope key, adding it as a candidate before the key itself.
* Similarly, when searching for a cluster name by version envelope, the function now returns the inner `cluster-name` or `nameref` if available, falling back to the envelope key only if the inner name is missing.