### PR TITLE
MLE-30475/BUGFix-upgrade HAProxy docker image to 3.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ e2e-setup-minikube: kustomize controller-gen build docker-build
 	kubectl get storageclass
 	minikube image load $(IMG)
 	minikube image load $(E2E_MARKLOGIC_IMAGE_VERSION)
-	minikube image load "docker.io/haproxytech/haproxy-alpine:3.2"
+	minikube image load "docker.io/haproxytech/haproxy-alpine:3.4.0"
 	minikube image load $(FLUENT_BIT_IMAGE)
 	minikube image ls
 
@@ -344,7 +344,7 @@ e2e-setup-minikube-istio: kustomize controller-gen build docker-build istioctl #
 	kubectl get pods -n istio-system
 	minikube image load $(IMG)
 	minikube image load $(E2E_MARKLOGIC_IMAGE_VERSION)
-	minikube image load "docker.io/haproxytech/haproxy-alpine:3.2"
+	minikube image load "docker.io/haproxytech/haproxy-alpine:3.4.0"
 	minikube image load $(FLUENT_BIT_IMAGE)
 	minikube image ls
 

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -109,7 +109,7 @@ type NetworkPolicy struct {
 }
 type HAProxy struct {
 	Enabled bool `json:"enabled,omitempty"`
-	// +kubebuilder:default:="haproxytech/haproxy-alpine:3.2"
+	// +kubebuilder:default:="haproxytech/haproxy-alpine:3.4.0"
 	Image            string                        `json:"image,omitempty"`
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// +kubebuilder:default:=1

--- a/charts/marklogic-operator-kubernetes/templates/marklogiccluster-crd.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/marklogiccluster-crd.yaml
@@ -4294,7 +4294,7 @@ spec:
                     format: int32
                     type: integer
                   image:
-                    default: haproxytech/haproxy-alpine:3.2
+                    default: haproxytech/haproxy-alpine:3.4.0
                     type: string
                   imagePullSecrets:
                     items:

--- a/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
+++ b/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
@@ -4302,7 +4302,7 @@ spec:
                     format: int32
                     type: integer
                   image:
-                    default: haproxytech/haproxy-alpine:3.2
+                    default: haproxytech/haproxy-alpine:3.4.0
                     type: string
                   imagePullSecrets:
                     items:


### PR DESCRIPTION
This pull request updates the default HAProxy image version used throughout the project from 3.2 to 3.4.0. The change ensures consistency across the codebase, documentation, and deployment configurations, and will affect both local development setups and cluster deployments.

**HAProxy Image Version Update:**

* Updated the default HAProxy image version from `haproxytech/haproxy-alpine:3.2` to `haproxytech/haproxy-alpine:3.4.0` in the `HAProxy` struct documentation in `api/v1/common_types.go`.
* Changed the default image in the MarkLogicCluster CRD YAML files (`charts/marklogic-operator-kubernetes/templates/marklogiccluster-crd.yaml` and `config/crd/bases/marklogic.progress.com_marklogicclusters.yaml`) to `haproxytech/haproxy-alpine:3.4.0`. [[1]](diffhunk://#diff-1b1114e56664951ae405082f64a701a2e6a4c12a7e9e93e29e069afe71477521L4297-R4297) [[2]](diffhunk://#diff-670d251f4de19e29847ee4c2464f8147d6388a8ede4bba8ce4f18c20a2feb5f6L4305-R4305)

**Development and E2E Setup:**

* Updated the `Makefile` to load `haproxytech/haproxy-alpine:3.4.0` instead of 3.2 for both standard and Istio-based Minikube E2E environments. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L327-R327) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L347-R347)