### PR TITLE
MLE-30476/BUGFix-manager-rbac

### DIFF
--- a/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
@@ -271,7 +271,7 @@ so the operator can read allowVolumeExpansion and perform PVC resize operations.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
 rules:
@@ -287,13 +287,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" . }}'

--- a/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
@@ -85,6 +85,23 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -215,6 +232,23 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
@@ -242,14 +242,6 @@ rules:
   - create
   - patch
   - update
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -270,4 +262,40 @@ subjects:
   name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" $ }}'
   namespace: '{{ $.Release.Namespace }}'
 {{- end }}
+{{- /*
+storageclass is a cluster-scoped resource; a namespaced Role cannot grant access
+to it. A dedicated ClusterRole + ClusterRoleBinding is required in namespace mode
+so the operator can read allowVolumeExpansion and perform PVC resize operations.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: marklogic-operator-storageclass-reader
+  labels:
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: marklogic-operator-storageclass-reader
+  labels:
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: marklogic-operator-storageclass-reader
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" . }}'
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -248,6 +248,31 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - daemonsets
@@ -302,6 +327,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -372,6 +405,31 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - daemonsets
@@ -426,6 +484,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -514,7 +514,7 @@ so the operator can read allowVolumeExpansion and perform PVC resize operations.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
 rules:
@@ -530,13 +530,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: marklogic-operator-storageclass-reader
+  name: {{ printf "%s-storageclass-reader" (include "marklogic-operator-kubernetes.fullname" .) | trunc 63 | trimSuffix "-" }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" . }}'

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -485,14 +485,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -513,6 +505,42 @@ subjects:
   name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" $ }}'
   namespace: '{{ $.Release.Namespace }}'
 {{- end }}
+{{- /*
+storageclass is a cluster-scoped resource; a namespaced Role cannot grant access
+to it. A dedicated ClusterRole + ClusterRoleBinding is required in namespace mode
+so the operator can read allowVolumeExpansion and perform PVC resize operations.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: marklogic-operator-storageclass-reader
+  labels:
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: marklogic-operator-storageclass-reader
+  labels:
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: marklogic-operator-storageclass-reader
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "marklogic-operator-kubernetes.serviceAccountName" . }}'
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}
 TMPL_EOF
     echo "  [manager-rbac.yaml] Done."


### PR DESCRIPTION
This pull request updates the RBAC (Role-Based Access Control) configuration for the MarkLogic Operator to ensure correct permissions for managing Kubernetes events, persistent volume claims (PVCs), and storage classes. The changes add necessary permissions for the operator to emit events, manage PVCs (including their status), and, importantly, introduce a dedicated ClusterRole and ClusterRoleBinding for reading storage classes, which is required for PVC resizing operations in namespace mode.

RBAC enhancements for operator functionality:

**Event and PVC permissions:**
* Added permissions for the operator to create, patch, and update events in both the core (`""`) and `events.k8s.io` API groups, ensuring it can emit Kubernetes events as needed. [[1]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035R88-R104) [[2]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035R236-R244) [[3]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R250-R274) [[4]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R407-R431)
* Granted the operator permissions to get, list, patch, update, and watch `persistentvolumeclaims` and to get `persistentvolumeclaims/status`, supporting advanced PVC management. [[1]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R250-R274) [[2]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R407-R431)

**StorageClass access for PVC resizing:**
* Introduced a dedicated `ClusterRole` and `ClusterRoleBinding` (`marklogic-operator-storageclass-reader`) to allow the operator to get, list, and watch `storageclasses`, which is necessary for reading `allowVolumeExpansion` and performing PVC resize operations. This addresses the limitation that storage classes are cluster-scoped and cannot be managed by a namespaced Role. [[1]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035R265-R300) [[2]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R331-R338) [[3]](diffhunk://#diff-79abb692cbade0a87b918c43f271320148834a6593303ab772ac0b5b878c0b67R508-R543)