### PR TITLE
MLE-30962 : fix Webhook and add E2E tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,9 +227,9 @@ void runEKSIstioE2eTests() {
     }
 }
 
-void runHelmNamespaceScopedE2eTests() {
+void runHelmNamespaceScopedE2eTests(String webhookCertProvider = 'selfSigned') {
     sh """
-        make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
+        E2E_HELM_WEBHOOK_CERT_PROVIDER=${webhookCertProvider} make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
     """
 }
 
@@ -328,16 +328,24 @@ pipeline {
         booleanParam(name: 'TEST_ON_EKS', defaultValue: false, description: 'Run e2e tests on the EKS cluster (jenkins-kube-ninjas) instead of Minikube. Requires KUBE_NINJAS_OPS_AWS_JENKINS credentials on this agent.')
         string(name: 'EKS_MARKLOGIC_IMAGE_TAG', defaultValue: 'latest-12', description: 'MarkLogic image tag to pull from the EKS ECR registry when TEST_ON_EKS=true. The full ECR URL is constructed at runtime from the AWS account ID resolved via STS.', trim: true)
         booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED', defaultValue: false, description: 'Run namespace-scoped e2e tests via Helm chart install (validates Role/RoleBinding, no ClusterRole)')
+        booleanParam(name: 'VERIFY_HELM_NAMESPACE_SCOPED_CERT_MANAGER', defaultValue: false, description: 'Run an additional namespace-scoped Helm e2e pass using webhook cert provider=certManager (opt-in, does not change default Helm flow)')
+        booleanParam(name: 'RUN_ONLY_HELM_NS_E2E', defaultValue: false, description: 'Run only the Run-Helm-NS-e2e-Tests stage (skips all other stages).')
     }
 
     stages {
         stage('Pre-Build-Check') {
+            when {
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false }
+            }
             steps {
                 preBuildCheck()
             }
         }
 
         stage('Run-tests') {
+            when {
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false }
+            }
             steps {
                 runTests()
             }
@@ -351,6 +359,9 @@ pipeline {
         // try/finally even when earlier stages throw.
         // -----------------------------------------------------------------------
         stage('E2E Tests') {
+            when {
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false }
+            }
             steps {
                 script {
                     if (params.TEST_ON_EKS && params.E2E_SCOPE != 'cluster') {
@@ -410,7 +421,7 @@ pipeline {
 
         stage('Helm-NS-Minikube-Setup') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false && params.E2E_SCOPE == 'cluster' }
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false && (params.VERIFY_HELM_NAMESPACE_SCOPED != false || params.VERIFY_HELM_NAMESPACE_SCOPED_CERT_MANAGER != false) && params.E2E_SCOPE == 'cluster' }
             }
             steps {
                 runMinikubeSetup()
@@ -419,16 +430,48 @@ pipeline {
 
         stage('Run-Helm-NS-e2e-Tests') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false && params.E2E_SCOPE == 'cluster' }
+                expression { return params.RUN_ONLY_HELM_NS_E2E != false || ((params.VERIFY_HELM_NAMESPACE_SCOPED != false || params.VERIFY_HELM_NAMESPACE_SCOPED_CERT_MANAGER != false) && params.E2E_SCOPE == 'cluster') }
             }
             steps {
-                runHelmNamespaceScopedE2eTests()
+                script {
+                    def runSelfSigned = params.VERIFY_HELM_NAMESPACE_SCOPED
+                    def runCertManager = params.VERIFY_HELM_NAMESPACE_SCOPED_CERT_MANAGER
+
+                    if (params.RUN_ONLY_HELM_NS_E2E && !runSelfSigned && !runCertManager) {
+                        // In run-only mode, default to the baseline self-signed path if no explicit variant is selected.
+                        runSelfSigned = true
+                    }
+
+                    def executeHelmNsTests = {
+                        if (runSelfSigned) {
+                            echo "Running namespace-scoped Helm e2e tests with webhook cert provider=selfSigned"
+                            runHelmNamespaceScopedE2eTests('selfSigned')
+                        }
+                        if (runCertManager) {
+                            echo "Running namespace-scoped Helm e2e tests with webhook cert provider=certManager"
+                            runHelmNamespaceScopedE2eTests('certManager')
+                        }
+                    }
+
+                    if (params.RUN_ONLY_HELM_NS_E2E) {
+                        try {
+                            runMinikubeSetup()
+                            executeHelmNsTests()
+                        } finally {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                runMinikubeCleanup()
+                            }
+                        }
+                    } else {
+                        executeHelmNsTests()
+                    }
+                }
             }
         }
 
         stage('Helm-NS-Cleanup') {
             when {
-                expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false && params.E2E_SCOPE == 'cluster' }
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false && (params.VERIFY_HELM_NAMESPACE_SCOPED != false || params.VERIFY_HELM_NAMESPACE_SCOPED_CERT_MANAGER != false) && params.E2E_SCOPE == 'cluster' }
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -440,9 +483,12 @@ pipeline {
         // Publish image to internal registries (conditional)
         stage('Publish Image') {
             when {
-                    anyOf {
-                        branch 'develop'
-                        expression { return params.PUBLISH_IMAGE }
+                    allOf {
+                        expression { return params.RUN_ONLY_HELM_NS_E2E == false }
+                        anyOf {
+                            branch 'develop'
+                            expression { return params.PUBLISH_IMAGE }
+                        }
                     }
             }
             steps {
@@ -451,6 +497,9 @@ pipeline {
         }
 
         stage('Run-BlackDuck-Scan') {
+            when {
+                expression { return params.RUN_ONLY_HELM_NS_E2E == false }
+            }
 
             steps {
                 runBlackDuckScan()

--- a/charts/marklogic-operator-kubernetes/templates/deployment.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/deployment.yaml
@@ -29,11 +29,13 @@ spec:
         - --metrics-bind-address=:8443
         - --metrics-secure=true
         - --leader-elect
+        - --webhook-port=9443
         {{- else }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --metrics-secure=false
         - --leader-elect
+        - --webhook-port=9443
         {{- end }}
         command:
         - /manager
@@ -44,6 +46,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ENABLE_NAMESPACE_WEBHOOK_VALIDATION
+          value: {{ .Values.webhook.namespaceValidation.enabled | quote }}
         {{- if eq .Values.scope.type "namespace" }}
         {{- $ns := .Values.scope.watchNamespaces }}
         {{- if not $ns }}
@@ -83,6 +87,10 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-server-cert
+          readOnly: true
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
@@ -93,3 +101,7 @@ spec:
       tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml .Values.controllerManager.topologySpreadConstraints
         | nindent 8 }}
+      volumes:
+      - name: webhook-server-cert
+        secret:
+          secretName: {{ .Values.webhook.certs.secretName }}

--- a/charts/marklogic-operator-kubernetes/templates/deployment.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/deployment.yaml
@@ -29,12 +29,13 @@ spec:
         - --metrics-bind-address=:8443
         - --metrics-secure=true
         - --leader-elect
-        - --webhook-port=9443
         {{- else }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --metrics-secure=false
         - --leader-elect
+        {{- end }}
+        {{- if .Values.webhook.enabled }}
         - --webhook-port=9443
         {{- end }}
         command:
@@ -46,8 +47,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.webhook.enabled }}
         - name: ENABLE_NAMESPACE_WEBHOOK_VALIDATION
           value: {{ .Values.webhook.namespaceValidation.enabled | quote }}
+        {{- end }}
         {{- if eq .Values.scope.type "namespace" }}
         {{- $ns := .Values.scope.watchNamespaces }}
         {{- if not $ns }}
@@ -87,10 +90,12 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+        {{- if .Values.webhook.enabled }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-server-cert
           readOnly: true
+        {{- end }}
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
@@ -101,7 +106,9 @@ spec:
       tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml .Values.controllerManager.topologySpreadConstraints
         | nindent 8 }}
+      {{- if .Values.webhook.enabled }}
       volumes:
       - name: webhook-server-cert
         secret:
           secretName: {{ .Values.webhook.certs.secretName }}
+      {{- end }}

--- a/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/manager-rbac.yaml
@@ -10,7 +10,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumeclaims
   - pods
   - secrets
   - serviceaccounts
@@ -26,9 +25,28 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims/status
   verbs:
   - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - apps
   resources:
@@ -85,15 +103,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
 - apiGroups:
   - storage.k8s.io
   resources:
@@ -158,7 +167,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumeclaims
   - pods
   - secrets
   - serviceaccounts
@@ -174,9 +182,28 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims/status
   verbs:
   - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - apps
   resources:
@@ -233,15 +260,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/marklogic-operator-kubernetes/templates/webhook-certs.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/webhook-certs.yaml
@@ -1,0 +1,166 @@
+{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "selfSigned") }}
+{{- $secretName := .Values.webhook.certs.secretName }}
+{{- $serviceName := .Values.webhook.certs.serviceName }}
+{{- $namespace := .Release.Namespace }}
+{{- $validity := int .Values.webhook.certs.selfSigned.validityDays }}
+{{- $existing := lookup "v1" "Secret" $namespace $secretName }}
+{{- $tlsCrt := "" }}
+{{- $tlsKey := "" }}
+{{- $caCrt := "" }}
+{{- if and $existing (hasKey $existing.data "tls.crt") (hasKey $existing.data "tls.key") (hasKey $existing.data "ca.crt") }}
+  {{- $tlsCrt = (index $existing.data "tls.crt") }}
+  {{- $tlsKey = (index $existing.data "tls.key") }}
+  {{- $caCrt = (index $existing.data "ca.crt") }}
+{{- else }}
+  {{- $ca := genCA (printf "%s-webhook-ca" (include "marklogic-operator-kubernetes.fullname" .)) $validity }}
+  {{- $cert := genSignedCert $serviceName nil (list (printf "%s.%s" $serviceName $namespace) (printf "%s.%s.svc" $serviceName $namespace) (printf "%s.%s.svc.cluster.local" $serviceName $namespace)) $validity $ca }}
+  {{- $tlsCrt = b64enc $cert.Cert }}
+  {{- $tlsKey = b64enc $cert.Key }}
+  {{- $caCrt = b64enc $ca.Cert }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $tlsCrt }}
+  tls.key: {{ $tlsKey }}
+  ca.crt: {{ $caCrt }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: marklogic-operator-validating-webhook
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+webhooks:
+- name: vmarklogicclusters.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicclusters
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogiccluster
+      port: {{ .Values.webhook.certs.port }}
+    caBundle: {{ $caCrt }}
+- name: vmarklogicgroups.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicgroups
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogicgroup
+      port: {{ .Values.webhook.certs.port }}
+    caBundle: {{ $caCrt }}
+{{- end }}
+---
+{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "certManager") .Values.webhook.certs.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.webhook.certs.certManager.certificateName }}
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.webhook.certs.secretName }}
+  issuerRef:
+    kind: {{ .Values.webhook.certs.certManager.issuerRef.kind }}
+    name: {{ .Values.webhook.certs.certManager.issuerRef.name }}
+    group: {{ .Values.webhook.certs.certManager.issuerRef.group }}
+  duration: {{ .Values.webhook.certs.certManager.duration }}
+  renewBefore: {{ .Values.webhook.certs.certManager.renewBefore }}
+  dnsNames:
+  - {{ .Values.webhook.certs.serviceName }}
+  - {{ printf "%s.%s" .Values.webhook.certs.serviceName .Release.Namespace }}
+  - {{ printf "%s.%s.svc" .Values.webhook.certs.serviceName .Release.Namespace }}
+  - {{ printf "%s.%s.svc.cluster.local" .Values.webhook.certs.serviceName .Release.Namespace }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: marklogic-operator-validating-webhook
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace .Values.webhook.certs.certManager.certificateName }}
+webhooks:
+- name: vmarklogicclusters.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicclusters
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogiccluster
+      port: {{ .Values.webhook.certs.port }}
+- name: vmarklogicgroups.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicgroups
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogicgroup
+      port: {{ .Values.webhook.certs.port }}
+{{- end }}

--- a/charts/marklogic-operator-kubernetes/templates/webhook-service.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/webhook-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.webhook.certs.serviceName }}
+  labels:
+    app.kubernetes.io/component: webhook
+    control-plane: controller-manager
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: webhook
+    port: {{ .Values.webhook.certs.port }}
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+  {{- include "marklogic-operator-kubernetes.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/marklogic-operator-kubernetes/templates/webhook-validation.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/webhook-validation.yaml
@@ -1,7 +1,0 @@
-{{- if and .Values.webhook.enabled (not (or (eq .Values.webhook.certs.provider "selfSigned") (eq .Values.webhook.certs.provider "certManager"))) }}
-{{- fail "Invalid configuration: webhook.certs.provider must be one of [selfSigned, certManager]." }}
-{{- end }}
-
-{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "certManager") (not .Values.webhook.certs.certManager.enabled) }}
-{{- fail "Invalid configuration: webhook.certs.provider=certManager requires webhook.certs.certManager.enabled=true." }}
-{{- end }}

--- a/charts/marklogic-operator-kubernetes/templates/webhook-validation.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/webhook-validation.yaml
@@ -1,10 +1,3 @@
-{{- /*
-Render-time validation: catch invalid value combinations before deploying.
-*/}}
-{{- if and (eq .Values.scope.type "namespace") .Values.metrics.secure }}
-{{- fail "Invalid configuration: metrics.secure=true is not supported when scope.type=namespace. The TokenReview/SubjectAccessReview ClusterRoles required for secure metrics are only rendered in cluster scope. Set metrics.secure=false when using namespace scope." }}
-{{- end }}
-
 {{- if and .Values.webhook.enabled (not (or (eq .Values.webhook.certs.provider "selfSigned") (eq .Values.webhook.certs.provider "certManager"))) }}
 {{- fail "Invalid configuration: webhook.certs.provider must be one of [selfSigned, certManager]." }}
 {{- end }}

--- a/charts/marklogic-operator-kubernetes/values.yaml
+++ b/charts/marklogic-operator-kubernetes/values.yaml
@@ -53,3 +53,32 @@ metrics:
   # secure: false            — HTTP on :8080, no authentication. Safe for namespace scope
   #                            or development environments that have no cluster-level RBAC.
   secure: true
+
+# Admission webhook configuration
+webhook:
+  enabled: true
+  failurePolicy: Fail
+  timeoutSeconds: 10
+
+  namespaceValidation:
+    enabled: true
+
+  certs:
+    # selfSigned | certManager
+    provider: selfSigned
+    secretName: marklogic-operator-webhook-server-cert
+    serviceName: marklogic-operator-webhook-service
+    port: 9443
+
+    selfSigned:
+      validityDays: 365
+
+    certManager:
+      enabled: false
+      certificateName: marklogic-operator-webhook-serving-cert
+      issuerRef:
+        kind: ClusterIssuer
+        name: marklogic-operator-selfsigned
+        group: cert-manager.io
+      duration: 8760h
+      renewBefore: 720h

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -40,6 +41,7 @@ import (
 
 	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
 	"github.com/marklogic/marklogic-operator-kubernetes/internal/controller"
+	operatorwebhook "github.com/marklogic/marklogic-operator-kubernetes/internal/webhook"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -61,6 +63,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var webhookPort int
 	var watchNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"The address the metrics endpoint binds to. Use :8443 when --metrics-secure is true.")
@@ -73,6 +76,8 @@ func main() {
 			"When true, --metrics-bind-address should also be changed to :8443.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.IntVar(&webhookPort, "webhook-port", 9443,
+		"The port the webhook server binds to.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"Namespace(s) to watch for resources. If empty, watches all namespaces (cluster-scoped). "+
 			"Can be a single namespace or comma-separated list of namespaces. "+
@@ -142,6 +147,8 @@ func main() {
 	}
 
 	webhookServer := webhook.NewServer(webhook.Options{
+		Port:    webhookPort,
+		CertDir: "/tmp/k8s-webhook-server/serving-certs",
 		TLSOpts: tlsOpts,
 	})
 
@@ -231,6 +238,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "MarklogicCluster")
 		os.Exit(1)
 	}
+
+	if isNamespaceValidationWebhookEnabled() {
+		operatorwebhook.RegisterNamespaceScopeValidationWebhooks(webhookServer)
+		setupLog.Info("namespace scope validation webhooks registered")
+	} else {
+		setupLog.Info("namespace scope validation webhooks are disabled")
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -247,4 +261,17 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func isNamespaceValidationWebhookEnabled() bool {
+	v := strings.TrimSpace(os.Getenv("ENABLE_NAMESPACE_WEBHOOK_VALIDATION"))
+	if v == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		setupLog.Error(err, "invalid ENABLE_NAMESPACE_WEBHOOK_VALIDATION value, defaulting to enabled", "value", v)
+		return true
+	}
+	return enabled
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -239,12 +238,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if isNamespaceValidationWebhookEnabled() {
-		operatorwebhook.RegisterNamespaceScopeValidationWebhooks(webhookServer)
-		setupLog.Info("namespace scope validation webhooks registered")
-	} else {
-		setupLog.Info("namespace scope validation webhooks are disabled")
-	}
+	// Always register the webhook handlers so the ValidatingWebhookConfiguration
+	// paths are served regardless of whether namespace validation is enabled.
+	// The handler itself returns Allowed when ENABLE_NAMESPACE_WEBHOOK_VALIDATION=false,
+	// avoiding 404/connection errors that would block CR create/update under failurePolicy: Fail.
+	operatorwebhook.RegisterNamespaceScopeValidationWebhooks(webhookServer, watchNamespace)
+	setupLog.Info("namespace scope validation webhooks registered",
+		"validationEnabled", os.Getenv("ENABLE_NAMESPACE_WEBHOOK_VALIDATION"))
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -261,17 +261,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func isNamespaceValidationWebhookEnabled() bool {
-	v := strings.TrimSpace(os.Getenv("ENABLE_NAMESPACE_WEBHOOK_VALIDATION"))
-	if v == "" {
-		return true
-	}
-	enabled, err := strconv.ParseBool(v)
-	if err != nil {
-		setupLog.Error(err, "invalid ENABLE_NAMESPACE_WEBHOOK_VALIDATION value, defaulting to enabled", "value", v)
-		return true
-	}
-	return enabled
 }

--- a/docs/WEBHOOK_VALIDATION_CERTS_DESIGN.md
+++ b/docs/WEBHOOK_VALIDATION_CERTS_DESIGN.md
@@ -1,0 +1,185 @@
+# Webhook Validation and Certificate Management Design
+
+## Objective
+
+Implement validating admission webhooks that reject `MarklogicCluster` and `MarklogicGroup` CRs when applied to namespaces outside the operator watch scope, with two certificate provider modes:
+
+1. `selfSigned` (default): no cert-manager dependency
+2. `certManager` (optional): cert-manager managed issuance and rotation
+
+## Current State Summary
+
+- Namespace watch scope is already configured through `WATCH_NAMESPACE` and manager cache scoping.
+- Webhook server object exists in manager startup (`cmd/main.go`), but webhook registration/resources are not fully wired in this chart path.
+- Chart currently focuses on controller deployment/RBAC and CRDs.
+
+## Proposed Helm Values Schema
+
+Add the following section to `charts/marklogic-operator-kubernetes/values.yaml`:
+
+```yaml
+webhook:
+  enabled: true
+  failurePolicy: Fail
+  timeoutSeconds: 10
+
+  namespaceValidation:
+    enabled: true
+
+  certs:
+    # selfSigned | certManager
+    provider: selfSigned
+
+    # shared settings
+    secretName: marklogic-operator-webhook-server-cert
+    serviceName: marklogic-operator-webhook-service
+    port: 9443
+
+    # self-signed mode
+    selfSigned:
+      regenerateOnUpgrade: false
+      validityDays: 365
+
+    # cert-manager mode
+    certManager:
+      enabled: false
+      issuerRef:
+        kind: ClusterIssuer
+        name: marklogic-operator-selfsigned
+        group: cert-manager.io
+      duration: 8760h
+      renewBefore: 720h
+```
+
+### Validation Rules
+
+- If `webhook.enabled=false`, no webhook resources are rendered.
+- If `webhook.certs.provider=certManager`, then `webhook.certs.certManager.enabled=true` must be set.
+- If `scope.type=namespace` and `webhook.namespaceValidation.enabled=true`, webhook denies CRs in namespaces not in watch scope.
+
+## Template Set
+
+Create these templates under `charts/marklogic-operator-kubernetes/templates/`:
+
+1. `webhook-service.yaml`
+- Defines service that routes to manager webhook port (`9443`).
+
+2. `validating-webhook-configuration.yaml`
+- Registers webhook for `marklogicclusters` and `marklogicgroups` on `CREATE`/`UPDATE`.
+- Uses configurable `failurePolicy` and `timeoutSeconds`.
+- References service + webhook path.
+- `caBundle` behavior depends on cert provider:
+  - `selfSigned`: set from generated CA bundle
+  - `certManager`: injected by cert-manager cainjector
+
+3. `webhook-certgen-job.yaml` (self-signed mode)
+- Helm hook Job (`pre-install,pre-upgrade`) that:
+  - Generates CA + server keypair with SANs:
+    - `<service>`
+    - `<service>.<namespace>`
+    - `<service>.<namespace>.svc`
+  - Creates/updates secret with `tls.crt`, `tls.key`, `ca.crt`
+  - Patches webhook `caBundle`
+- Recommended hook metadata:
+  - `helm.sh/hook: pre-install,pre-upgrade`
+  - `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`
+
+4. `certmanager-issuer.yaml` (optional)
+- Optional Issuer/ClusterIssuer helper (if chart should provision one).
+
+5. `certmanager-certificate.yaml` (cert-manager mode)
+- Creates `Certificate` resource writing to shared webhook secret.
+- Includes dnsNames for webhook service identity.
+
+## Deployment Template Changes
+
+Update `templates/deployment.yaml` manager container:
+
+1. Add webhook args:
+- `--webhook-port=9443`
+
+2. Add cert volume mount:
+- Mount path: `/tmp/k8s-webhook-server/serving-certs`
+
+3. Add secret volume:
+- Secret name from `webhook.certs.secretName`
+
+## Manager Runtime Changes
+
+In `cmd/main.go`, set explicit webhook options:
+
+```go
+webhookServer := webhook.NewServer(webhook.Options{
+    Port:    9443,
+    CertDir: "/tmp/k8s-webhook-server/serving-certs",
+    TLSOpts: tlsOpts,
+})
+```
+
+Register validation handlers for:
+
+- `MarklogicCluster` create/update
+- `MarklogicGroup` create/update
+
+## Namespace Validation Logic
+
+For each admission request:
+
+1. Read incoming object namespace from AdmissionReview request.
+2. Determine allowed namespaces from `WATCH_NAMESPACE`:
+- empty => cluster-scoped, allow all
+- non-empty => parse comma-separated namespace list
+3. If namespace is not allowed, reject request with clear message:
+
+`namespace <ns> is outside operator watch scope (<watchNamespaces>)`
+
+This ensures apply-time failure instead of silent non-reconciliation.
+
+## Certificate Generation and Storage
+
+### Mode A: selfSigned
+
+Generation:
+- Helm hook Job generates CA and serving certificate.
+
+Storage:
+- Kubernetes Secret in operator namespace (name from `webhook.certs.secretName`):
+  - `tls.crt`
+  - `tls.key`
+  - `ca.crt`
+
+Distribution:
+- Manager pod mounts secret for TLS serving cert.
+- Webhook `caBundle` patched from `ca.crt`.
+
+Rotation:
+- Triggered on upgrade or explicit regeneration policy.
+
+### Mode B: certManager
+
+Generation:
+- cert-manager issues serving cert from configured issuer.
+
+Storage:
+- Same Secret name (`webhook.certs.secretName`) maintained by cert-manager.
+
+Distribution:
+- Manager pod mounts secret for serving TLS.
+- cainjector injects CA into `ValidatingWebhookConfiguration`.
+
+Rotation:
+- Automatic via cert-manager renewal settings.
+
+## Suggested Rollout Plan
+
+1. Implement `selfSigned` first as default path.
+2. Add cert-manager provider support using same secret contract.
+3. Enable namespace validation webhook with `failurePolicy=Fail` by default.
+4. Add chart tests for both providers and namespace denial behavior.
+
+## Security and Operational Notes
+
+- Keep webhook timeout low (`10s` default).
+- Use `sideEffects: None` and `admissionReviewVersions: ["v1"]`.
+- Ensure cert SANs exactly match service DNS names used by API server.
+- Keep one secret contract for both providers to avoid deployment branching complexity.

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -20,6 +20,9 @@ METRICS_AUTH_RBAC_FILE="${TEMPLATES_DIR}/metrics-auth-rbac.yaml"
 METRICS_READER_RBAC_FILE="${TEMPLATES_DIR}/metrics-reader-rbac.yaml"
 METRICS_SERVICE_FILE="${TEMPLATES_DIR}/metrics-service.yaml"
 PROXY_RBAC_FILE="${TEMPLATES_DIR}/proxy-rbac.yaml"
+WEBHOOK_SERVICE_FILE="${TEMPLATES_DIR}/webhook-service.yaml"
+WEBHOOK_CERTS_FILE="${TEMPLATES_DIR}/webhook-certs.yaml"
+WEBHOOK_VALIDATION_FILE="${TEMPLATES_DIR}/webhook-validation.yaml"
 
 echo "=== helmify post-process: restoring scope + metrics-security support ==="
 
@@ -79,6 +82,44 @@ YAML_EOF
     echo "  [values.yaml] Done (metrics)."
 else
     echo "  [values.yaml] metrics already present – skipping."
+fi
+
+if ! grep -q "^webhook:" "${VALUES_FILE}"; then
+    echo "  [values.yaml] Adding webhook configuration..."
+    cat >> "${VALUES_FILE}" << 'YAML_EOF'
+
+# Admission webhook configuration
+webhook:
+  enabled: true
+  failurePolicy: Fail
+  timeoutSeconds: 10
+
+  namespaceValidation:
+    enabled: true
+
+  certs:
+    # selfSigned | certManager
+    provider: selfSigned
+    secretName: marklogic-operator-webhook-server-cert
+    serviceName: marklogic-operator-webhook-service
+    port: 9443
+
+    selfSigned:
+      validityDays: 365
+
+    certManager:
+      enabled: false
+      certificateName: marklogic-operator-webhook-serving-cert
+      issuerRef:
+        kind: ClusterIssuer
+        name: marklogic-operator-selfsigned
+        group: cert-manager.io
+      duration: 8760h
+      renewBefore: 720h
+YAML_EOF
+    echo "  [values.yaml] Done (webhook)."
+else
+    echo "  [values.yaml] webhook already present – skipping."
 fi
 
 # Strip manager.args block if helmify re-added it (hardcoded in deployment.yaml template)
@@ -215,6 +256,77 @@ print("  [deployment.yaml] Done (POD_NAMESPACE + WATCH_NAMESPACE).")
 PYEOF
 else
     echo "  [deployment.yaml] WATCH_NAMESPACE already present – skipping."
+fi
+
+# 2d. Add webhook-specific args/env/mounts/volumes used by the admission server.
+if ! grep -q -- "--webhook-port=9443" "${DEPLOYMENT_FILE}"; then
+  echo "  [deployment.yaml] Injecting webhook port arg..."
+  python3 - "${DEPLOYMENT_FILE}" << 'PYEOF'
+import sys
+path = sys.argv[1]
+with open(path, 'r') as f:
+  content = f.read()
+content = content.replace('- --leader-elect\n', '- --leader-elect\n        - --webhook-port=9443\n')
+with open(path, 'w') as f:
+  f.write(content)
+print("  [deployment.yaml] Done (webhook arg).")
+PYEOF
+else
+  echo "  [deployment.yaml] webhook port arg already present – skipping."
+fi
+
+if ! grep -q "ENABLE_NAMESPACE_WEBHOOK_VALIDATION" "${DEPLOYMENT_FILE}"; then
+  echo "  [deployment.yaml] Injecting ENABLE_NAMESPACE_WEBHOOK_VALIDATION env var..."
+  python3 - "${DEPLOYMENT_FILE}" << 'PYEOF'
+import sys
+path = sys.argv[1]
+with open(path, 'r') as f:
+  content = f.read()
+anchor = '        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n'
+insert = anchor + '        - name: ENABLE_NAMESPACE_WEBHOOK_VALIDATION\n          value: {{ .Values.webhook.namespaceValidation.enabled | quote }}\n'
+if anchor in content:
+  content = content.replace(anchor, insert, 1)
+  with open(path, 'w') as f:
+    f.write(content)
+  print("  [deployment.yaml] Done (webhook env).")
+else:
+  print("  WARNING: could not find POD_NAMESPACE anchor for webhook env injection.")
+PYEOF
+else
+  echo "  [deployment.yaml] webhook env already present – skipping."
+fi
+
+if ! grep -q "serving-certs" "${DEPLOYMENT_FILE}"; then
+  echo "  [deployment.yaml] Injecting webhook cert volume mount + secret volume..."
+  python3 - "${DEPLOYMENT_FILE}" << 'PYEOF'
+import sys
+path = sys.argv[1]
+with open(path, 'r') as f:
+  content = f.read()
+
+container_anchor = '        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext\n          | nindent 10 }}\n'
+container_insert = container_anchor + '        volumeMounts:\n        - mountPath: /tmp/k8s-webhook-server/serving-certs\n          name: webhook-server-cert\n          readOnly: true\n'
+
+pod_anchor = '      topologySpreadConstraints: {{- toYaml .Values.controllerManager.topologySpreadConstraints\n        | nindent 8 }}\n'
+pod_insert = pod_anchor + '      volumes:\n      - name: webhook-server-cert\n        secret:\n          secretName: {{ .Values.webhook.certs.secretName }}\n'
+
+changed = False
+if container_anchor in content:
+  content = content.replace(container_anchor, container_insert, 1)
+  changed = True
+if pod_anchor in content:
+  content = content.replace(pod_anchor, pod_insert, 1)
+  changed = True
+
+if changed:
+  with open(path, 'w') as f:
+    f.write(content)
+  print("  [deployment.yaml] Done (webhook mount/volume).")
+else:
+  print("  WARNING: could not find deployment anchors for webhook mount/volume injection.")
+PYEOF
+else
+  echo "  [deployment.yaml] webhook mount/volume already present – skipping."
 fi
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -648,5 +760,211 @@ else
         echo "  [metrics-service.yaml] metrics.secure conditional port already present – skipping."
     fi
 fi
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 7. Webhook templates – generated post-helmify so make helm does not overwrite.
+# ──────────────────────────────────────────────────────────────────────────────
+echo "  [webhook templates] Writing webhook service/certs/validation templates..."
+cat > "${WEBHOOK_SERVICE_FILE}" << 'TMPL_EOF'
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.webhook.certs.serviceName }}
+  labels:
+    app.kubernetes.io/component: webhook
+    control-plane: controller-manager
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: webhook
+    port: {{ .Values.webhook.certs.port }}
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+  {{- include "marklogic-operator-kubernetes.selectorLabels" . | nindent 4 }}
+{{- end }}
+TMPL_EOF
+
+cat > "${WEBHOOK_CERTS_FILE}" << 'TMPL_EOF'
+{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "selfSigned") }}
+{{- $secretName := .Values.webhook.certs.secretName }}
+{{- $serviceName := .Values.webhook.certs.serviceName }}
+{{- $namespace := .Release.Namespace }}
+{{- $validity := int .Values.webhook.certs.selfSigned.validityDays }}
+{{- $existing := lookup "v1" "Secret" $namespace $secretName }}
+{{- $tlsCrt := "" }}
+{{- $tlsKey := "" }}
+{{- $caCrt := "" }}
+{{- if and $existing (hasKey $existing.data "tls.crt") (hasKey $existing.data "tls.key") (hasKey $existing.data "ca.crt") }}
+  {{- $tlsCrt = (index $existing.data "tls.crt") }}
+  {{- $tlsKey = (index $existing.data "tls.key") }}
+  {{- $caCrt = (index $existing.data "ca.crt") }}
+{{- else }}
+  {{- $ca := genCA (printf "%s-webhook-ca" (include "marklogic-operator-kubernetes.fullname" .)) $validity }}
+  {{- $cert := genSignedCert $serviceName nil (list (printf "%s.%s" $serviceName $namespace) (printf "%s.%s.svc" $serviceName $namespace) (printf "%s.%s.svc.cluster.local" $serviceName $namespace)) $validity $ca }}
+  {{- $tlsCrt = b64enc $cert.Cert }}
+  {{- $tlsKey = b64enc $cert.Key }}
+  {{- $caCrt = b64enc $ca.Cert }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $tlsCrt }}
+  tls.key: {{ $tlsKey }}
+  ca.crt: {{ $caCrt }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: marklogic-operator-validating-webhook
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+webhooks:
+- name: vmarklogicclusters.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicclusters
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogiccluster
+      port: {{ .Values.webhook.certs.port }}
+    caBundle: {{ $caCrt }}
+- name: vmarklogicgroups.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicgroups
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogicgroup
+      port: {{ .Values.webhook.certs.port }}
+    caBundle: {{ $caCrt }}
+{{- end }}
+---
+{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "certManager") .Values.webhook.certs.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.webhook.certs.certManager.certificateName }}
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.webhook.certs.secretName }}
+  issuerRef:
+    kind: {{ .Values.webhook.certs.certManager.issuerRef.kind }}
+    name: {{ .Values.webhook.certs.certManager.issuerRef.name }}
+    group: {{ .Values.webhook.certs.certManager.issuerRef.group }}
+  duration: {{ .Values.webhook.certs.certManager.duration }}
+  renewBefore: {{ .Values.webhook.certs.certManager.renewBefore }}
+  dnsNames:
+  - {{ .Values.webhook.certs.serviceName }}
+  - {{ printf "%s.%s" .Values.webhook.certs.serviceName .Release.Namespace }}
+  - {{ printf "%s.%s.svc" .Values.webhook.certs.serviceName .Release.Namespace }}
+  - {{ printf "%s.%s.svc.cluster.local" .Values.webhook.certs.serviceName .Release.Namespace }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: marklogic-operator-validating-webhook
+  labels:
+    app.kubernetes.io/component: webhook
+  {{- include "marklogic-operator-kubernetes.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace .Values.webhook.certs.certManager.certificateName }}
+webhooks:
+- name: vmarklogicclusters.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicclusters
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogiccluster
+      port: {{ .Values.webhook.certs.port }}
+- name: vmarklogicgroups.marklogic.progress.com
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - marklogic.progress.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - marklogicgroups
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ .Values.webhook.certs.serviceName }}
+      path: /validate-marklogic-progress-com-v1-marklogicgroup
+      port: {{ .Values.webhook.certs.port }}
+{{- end }}
+TMPL_EOF
+
+cat > "${WEBHOOK_VALIDATION_FILE}" << 'TMPL_EOF'
+{{- if and .Values.webhook.enabled (not (or (eq .Values.webhook.certs.provider "selfSigned") (eq .Values.webhook.certs.provider "certManager"))) }}
+{{- fail "Invalid configuration: webhook.certs.provider must be one of [selfSigned, certManager]." }}
+{{- end }}
+
+{{- if and .Values.webhook.enabled (eq .Values.webhook.certs.provider "certManager") (not .Values.webhook.certs.certManager.enabled) }}
+{{- fail "Invalid configuration: webhook.certs.provider=certManager requires webhook.certs.certManager.enabled=true." }}
+{{- end }}
+TMPL_EOF
+echo "  [webhook templates] Done."
 
 echo "=== Post-processing complete ==="

--- a/hack/helmify-post-process.sh
+++ b/hack/helmify-post-process.sh
@@ -20,6 +20,7 @@ METRICS_AUTH_RBAC_FILE="${TEMPLATES_DIR}/metrics-auth-rbac.yaml"
 METRICS_READER_RBAC_FILE="${TEMPLATES_DIR}/metrics-reader-rbac.yaml"
 METRICS_SERVICE_FILE="${TEMPLATES_DIR}/metrics-service.yaml"
 PROXY_RBAC_FILE="${TEMPLATES_DIR}/proxy-rbac.yaml"
+VALIDATION_FILE="${TEMPLATES_DIR}/validation.yaml"
 WEBHOOK_SERVICE_FILE="${TEMPLATES_DIR}/webhook-service.yaml"
 WEBHOOK_CERTS_FILE="${TEMPLATES_DIR}/webhook-certs.yaml"
 WEBHOOK_VALIDATION_FILE="${TEMPLATES_DIR}/webhook-validation.yaml"
@@ -266,10 +267,16 @@ import sys
 path = sys.argv[1]
 with open(path, 'r') as f:
   content = f.read()
-content = content.replace('- --leader-elect\n', '- --leader-elect\n        - --webhook-port=9443\n')
-with open(path, 'w') as f:
-  f.write(content)
-print("  [deployment.yaml] Done (webhook arg).")
+anchor = '        {{- end }}\n        command:\n'
+insert = '        {{- end }}\n        {{- if .Values.webhook.enabled }}\n        - --webhook-port=9443\n        {{- end }}\n        command:\n'
+if anchor in content:
+  content = content.replace(anchor, insert, 1)
+  with open(path, 'w') as f:
+    f.write(content)
+  print("  [deployment.yaml] Done (webhook arg).")
+else:
+  print("  WARNING: metrics.secure end anchor not found for webhook arg injection.")
+  sys.exit(1)
 PYEOF
 else
   echo "  [deployment.yaml] webhook port arg already present – skipping."
@@ -283,7 +290,7 @@ path = sys.argv[1]
 with open(path, 'r') as f:
   content = f.read()
 anchor = '        - name: POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n'
-insert = anchor + '        - name: ENABLE_NAMESPACE_WEBHOOK_VALIDATION\n          value: {{ .Values.webhook.namespaceValidation.enabled | quote }}\n'
+insert = anchor + '        {{- if .Values.webhook.enabled }}\n        - name: ENABLE_NAMESPACE_WEBHOOK_VALIDATION\n          value: {{ .Values.webhook.namespaceValidation.enabled | quote }}\n        {{- end }}\n'
 if anchor in content:
   content = content.replace(anchor, insert, 1)
   with open(path, 'w') as f:
@@ -305,10 +312,10 @@ with open(path, 'r') as f:
   content = f.read()
 
 container_anchor = '        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext\n          | nindent 10 }}\n'
-container_insert = container_anchor + '        volumeMounts:\n        - mountPath: /tmp/k8s-webhook-server/serving-certs\n          name: webhook-server-cert\n          readOnly: true\n'
+container_insert = container_anchor + '        {{- if .Values.webhook.enabled }}\n        volumeMounts:\n        - mountPath: /tmp/k8s-webhook-server/serving-certs\n          name: webhook-server-cert\n          readOnly: true\n        {{- end }}\n'
 
 pod_anchor = '      topologySpreadConstraints: {{- toYaml .Values.controllerManager.topologySpreadConstraints\n        | nindent 8 }}\n'
-pod_insert = pod_anchor + '      volumes:\n      - name: webhook-server-cert\n        secret:\n          secretName: {{ .Values.webhook.certs.secretName }}\n'
+pod_insert = pod_anchor + '      {{- if .Values.webhook.enabled }}\n      volumes:\n      - name: webhook-server-cert\n        secret:\n          secretName: {{ .Values.webhook.certs.secretName }}\n      {{- end }}\n'
 
 changed = False
 if container_anchor in content:
@@ -956,7 +963,17 @@ webhooks:
 {{- end }}
 TMPL_EOF
 
-cat > "${WEBHOOK_VALIDATION_FILE}" << 'TMPL_EOF'
+# Keep webhook validation fail-rules in templates/validation.yaml only.
+# Remove legacy duplicate template if it exists to avoid drift.
+if [ -f "${WEBHOOK_VALIDATION_FILE}" ]; then
+  rm -f "${WEBHOOK_VALIDATION_FILE}"
+  echo "  [webhook templates] Removed duplicate webhook-validation.yaml (rules are in validation.yaml)."
+fi
+
+# Ensure webhook validation rules exist in the single source template.
+if [ -f "${VALIDATION_FILE}" ] && ! grep -q "webhook.certs.provider must be one of" "${VALIDATION_FILE}"; then
+  cat >> "${VALIDATION_FILE}" << 'TMPL_EOF'
+
 {{- if and .Values.webhook.enabled (not (or (eq .Values.webhook.certs.provider "selfSigned") (eq .Values.webhook.certs.provider "certManager"))) }}
 {{- fail "Invalid configuration: webhook.certs.provider must be one of [selfSigned, certManager]." }}
 {{- end }}
@@ -965,6 +982,11 @@ cat > "${WEBHOOK_VALIDATION_FILE}" << 'TMPL_EOF'
 {{- fail "Invalid configuration: webhook.certs.provider=certManager requires webhook.certs.certManager.enabled=true." }}
 {{- end }}
 TMPL_EOF
+  echo "  [validation.yaml] Added webhook validation rules."
+else
+  echo "  [validation.yaml] webhook validation rules already present – skipping."
+fi
+
 echo "  [webhook templates] Done."
 
 echo "=== Post-processing complete ==="

--- a/internal/webhook/namespace_scope_validation.go
+++ b/internal/webhook/namespace_scope_validation.go
@@ -75,10 +75,19 @@ func IsNamespaceAllowed(watchNamespaces []string, requestNamespace string) bool 
 }
 
 type namespaceScopeValidator struct {
-	watchNamespaces []string
+	watchNamespaces   []string
+	validationEnabled bool
 }
 
 func (v *namespaceScopeValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	// When namespace validation is disabled the handler is still registered so the
+	// webhook server answers the ValidatingWebhookConfiguration paths correctly.
+	// Returning Allowed here avoids 404/connection failures that would block CR
+	// create/update when failurePolicy: Fail is set on the webhook configuration.
+	if !v.validationEnabled {
+		return admission.Allowed("namespace scope validation is disabled")
+	}
+
 	if IsNamespaceAllowed(v.watchNamespaces, req.Namespace) {
 		return admission.Allowed("namespace is in operator watch scope")
 	}
@@ -88,10 +97,36 @@ func (v *namespaceScopeValidator) Handle(_ context.Context, req admission.Reques
 	return admission.Denied(msg)
 }
 
-// RegisterNamespaceScopeValidationWebhooks registers validating admission handlers
-// for MarklogicCluster and MarklogicGroup create/update requests.
-func RegisterNamespaceScopeValidationWebhooks(server ctrlwebhook.Server) {
-	validator := &namespaceScopeValidator{watchNamespaces: WatchNamespacesFromEnv(os.Getenv("WATCH_NAMESPACE"))}
+// RegisterNamespaceScopeValidationWebhooks always registers validating admission
+// handlers for MarklogicCluster and MarklogicGroup create/update requests.
+// The ENABLE_NAMESPACE_WEBHOOK_VALIDATION env var controls whether the handler
+// enforces scope or passes all requests through — the paths are always served
+// so the API server never receives a 404/connection error.
+//
+// watchNamespaceRaw must be the same raw value resolved by cmd/main.go (from
+// --watch-namespace or WATCH_NAMESPACE fallback) so webhook enforcement matches
+// the controller cache scope.
+func RegisterNamespaceScopeValidationWebhooks(server ctrlwebhook.Server, watchNamespaceRaw string) {
+	enabled := parseValidationEnabled(os.Getenv("ENABLE_NAMESPACE_WEBHOOK_VALIDATION"))
+	validator := &namespaceScopeValidator{
+		watchNamespaces:   WatchNamespacesFromEnv(watchNamespaceRaw),
+		validationEnabled: enabled,
+	}
 	server.Register(marklogicClusterValidatePath, &admission.Webhook{Handler: validator})
 	server.Register(marklogicGroupValidatePath, &admission.Webhook{Handler: validator})
+}
+
+// parseValidationEnabled parses ENABLE_NAMESPACE_WEBHOOK_VALIDATION.
+// An empty or unset value defaults to enabled (true).
+func parseValidationEnabled(raw string) bool {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return true
+	}
+	switch strings.ToLower(v) {
+	case "false", "0", "no":
+		return false
+	default:
+		return true
+	}
 }

--- a/internal/webhook/namespace_scope_validation.go
+++ b/internal/webhook/namespace_scope_validation.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	marklogicClusterValidatePath = "/validate-marklogic-progress-com-v1-marklogiccluster"
+	marklogicGroupValidatePath   = "/validate-marklogic-progress-com-v1-marklogicgroup"
+)
+
+// WatchNamespacesFromEnv parses WATCH_NAMESPACE and returns a sorted, de-duplicated list.
+// Empty result means cluster-scoped mode (all namespaces allowed).
+func WatchNamespacesFromEnv(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	uniq := make(map[string]struct{})
+	for _, ns := range strings.Split(raw, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			continue
+		}
+		uniq[ns] = struct{}{}
+	}
+
+	if len(uniq) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(uniq))
+	for ns := range uniq {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsNamespaceAllowed returns true when a request namespace is allowed by WATCH_NAMESPACE.
+// Empty watch list means cluster-scoped mode where all namespaces are allowed.
+func IsNamespaceAllowed(watchNamespaces []string, requestNamespace string) bool {
+	if len(watchNamespaces) == 0 {
+		return true
+	}
+	for _, ns := range watchNamespaces {
+		if ns == requestNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+type namespaceScopeValidator struct {
+	watchNamespaces []string
+}
+
+func (v *namespaceScopeValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	if IsNamespaceAllowed(v.watchNamespaces, req.Namespace) {
+		return admission.Allowed("namespace is in operator watch scope")
+	}
+
+	allowed := strings.Join(v.watchNamespaces, ",")
+	msg := fmt.Sprintf("namespace %q is outside operator watch scope (%s)", req.Namespace, allowed)
+	return admission.Denied(msg)
+}
+
+// RegisterNamespaceScopeValidationWebhooks registers validating admission handlers
+// for MarklogicCluster and MarklogicGroup create/update requests.
+func RegisterNamespaceScopeValidationWebhooks(server ctrlwebhook.Server) {
+	validator := &namespaceScopeValidator{watchNamespaces: WatchNamespacesFromEnv(os.Getenv("WATCH_NAMESPACE"))}
+	server.Register(marklogicClusterValidatePath, &admission.Webhook{Handler: validator})
+	server.Register(marklogicGroupValidatePath, &admission.Webhook{Handler: validator})
+}

--- a/internal/webhook/namespace_scope_validation_test.go
+++ b/internal/webhook/namespace_scope_validation_test.go
@@ -64,7 +64,7 @@ func TestIsNamespaceAllowed(t *testing.T) {
 }
 
 func TestNamespaceScopeValidatorHandle(t *testing.T) {
-	validator := &namespaceScopeValidator{watchNamespaces: []string{"ml", "prod"}}
+	validator := &namespaceScopeValidator{watchNamespaces: []string{"ml", "prod"}, validationEnabled: true}
 
 	allowedResp := validator.Handle(t.Context(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "ml"},
@@ -84,5 +84,21 @@ func TestNamespaceScopeValidatorHandle(t *testing.T) {
 	}
 	if !strings.Contains(deniedResp.Result.Message, "ml,prod") {
 		t.Fatalf("expected denial message to contain allowed namespaces, got %q", deniedResp.Result.Message)
+	}
+}
+
+func TestNamespaceScopeValidatorHandle_ValidationDisabled(t *testing.T) {
+	// When validationEnabled=false the handler must return Allowed for any namespace,
+	// including non-watched ones, so the webhook paths answer without blocking CRs.
+	validator := &namespaceScopeValidator{watchNamespaces: []string{"ml", "prod"}, validationEnabled: false}
+
+	resp := validator.Handle(t.Context(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "dev"},
+	})
+	if !resp.Allowed {
+		t.Fatalf("expected non-watched namespace to be allowed when validation is disabled, got denied: %s", resp.Result.Message)
+	}
+	if !strings.Contains(resp.Result.Message, "disabled") {
+		t.Fatalf("expected message to mention 'disabled', got %q", resp.Result.Message)
 	}
 }

--- a/internal/webhook/namespace_scope_validation_test.go
+++ b/internal/webhook/namespace_scope_validation_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestWatchNamespacesFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "empty means cluster scoped", raw: "", want: nil},
+		{name: "single namespace", raw: "ml", want: []string{"ml"}},
+		{name: "csv trims and deduplicates", raw: " ml,prod, ml ,dev ", want: []string{"dev", "ml", "prod"}},
+		{name: "ignores blank entries", raw: ",,ml,,", want: []string{"ml"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WatchNamespacesFromEnv(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("unexpected length: got=%v want=%v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("unexpected value at %d: got=%q want=%q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsNamespaceAllowed(t *testing.T) {
+	if !IsNamespaceAllowed(nil, "any") {
+		t.Fatal("expected cluster-scoped mode to allow any namespace")
+	}
+	if !IsNamespaceAllowed([]string{"ml", "prod"}, "ml") {
+		t.Fatal("expected watched namespace to be allowed")
+	}
+	if IsNamespaceAllowed([]string{"ml", "prod"}, "dev") {
+		t.Fatal("expected non-watched namespace to be denied")
+	}
+}
+
+func TestNamespaceScopeValidatorHandle(t *testing.T) {
+	validator := &namespaceScopeValidator{watchNamespaces: []string{"ml", "prod"}}
+
+	allowedResp := validator.Handle(t.Context(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "ml"},
+	})
+	if !allowedResp.Allowed {
+		t.Fatal("expected watched namespace request to be allowed")
+	}
+
+	deniedResp := validator.Handle(t.Context(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "dev"},
+	})
+	if deniedResp.Allowed {
+		t.Fatal("expected non-watched namespace request to be denied")
+	}
+	if !strings.Contains(deniedResp.Result.Message, "outside operator watch scope") {
+		t.Fatalf("expected denial message to mention watch scope, got %q", deniedResp.Result.Message)
+	}
+	if !strings.Contains(deniedResp.Result.Message, "ml,prod") {
+		t.Fatalf("expected denial message to contain allowed namespaces, got %q", deniedResp.Result.Message)
+	}
+}

--- a/test/e2e-helm/10_webhook_namespace_validation_test.go
+++ b/test/e2e-helm/10_webhook_namespace_validation_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package e2ehelm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	webhookWatchedNamespace   = "ml-ns-test"
+	webhookUnwatchedNamespace = "ml-ns-unwatched"
+	webhookCertificateName    = "marklogic-operator-webhook-serving-cert"
+)
+
+func TestNamespaceValidationWebhook(t *testing.T) {
+	trackTest(t)
+	feature := features.New("Namespace Validation Webhook").
+		WithLabel("type", "webhook-namespace-validation")
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: webhookUnwatchedNamespace}}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("failed to create unwatched namespace %s: %v", webhookUnwatchedNamespace, err)
+		}
+		return ctx
+	})
+
+	feature.Assess("CR denied in non-watched namespace", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		manifestPath := writeTempMarklogicClusterManifest(t, webhookUnwatchedNamespace, "webhook-denied")
+		defer os.Remove(manifestPath)
+
+		cmd := exec.Command("kubectl", "apply", "--dry-run=server", "-f", manifestPath)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected admission denial for namespace %s, but apply succeeded: %s", webhookUnwatchedNamespace, string(output))
+		}
+
+		out := string(output)
+		if !strings.Contains(out, "outside operator watch scope") {
+			t.Fatalf("expected denial message to mention watch scope, got: %s", out)
+		}
+		if !strings.Contains(out, webhookUnwatchedNamespace) {
+			t.Fatalf("expected denial message to include namespace %s, got: %s", webhookUnwatchedNamespace, out)
+		}
+		return ctx
+	})
+
+	feature.Assess("CR accepted in watched namespace", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		manifestPath := writeTempMarklogicClusterManifest(t, webhookWatchedNamespace, "webhook-allowed")
+		defer os.Remove(manifestPath)
+
+		cmd := exec.Command("kubectl", "apply", "--dry-run=server", "-f", manifestPath)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("expected apply to succeed in watched namespace %s, got error: %v output: %s", webhookWatchedNamespace, err, string(output))
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: webhookUnwatchedNamespace}}
+		if err := client.Resources().Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("warning: failed to delete namespace %s: %v", webhookUnwatchedNamespace, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func TestNamespaceValidationWebhookWithCertManager(t *testing.T) {
+	trackTest(t)
+	if webhookCerts != "certmanager" {
+		t.Skip("set E2E_HELM_WEBHOOK_CERT_PROVIDER=certManager to run cert-manager webhook validation")
+	}
+
+	feature := features.New("Namespace Validation Webhook with cert-manager").
+		WithLabel("type", "webhook-namespace-validation-certmanager")
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: webhookUnwatchedNamespace}}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("failed to create unwatched namespace %s: %v", webhookUnwatchedNamespace, err)
+		}
+		return ctx
+	})
+
+	feature.Assess("cert-manager Certificate becomes ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cmd := exec.Command(
+			"kubectl", "wait",
+			fmt.Sprintf("certificate/%s", webhookCertificateName),
+			"-n", helmNS,
+			"--for=condition=Ready",
+			"--timeout=3m",
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("webhook certificate did not become ready: %v output: %s", err, string(output))
+		}
+		return ctx
+	})
+
+	feature.Assess("validating webhook uses cert-manager CA injection", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cmd := exec.Command(
+			"kubectl", "get", "validatingwebhookconfiguration", "marklogic-operator-validating-webhook",
+			"-o", `jsonpath={.metadata.annotations.cert-manager\.io/inject-ca-from}`,
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed reading validating webhook annotation: %v output: %s", err, string(output))
+		}
+
+		expected := fmt.Sprintf("%s/%s", helmNS, webhookCertificateName)
+		if strings.TrimSpace(string(output)) != expected {
+			t.Fatalf("unexpected cert-manager injection annotation value, expected %s got %s", expected, strings.TrimSpace(string(output)))
+		}
+		return ctx
+	})
+
+	feature.Assess("CR denied in non-watched namespace", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		assertWebhookDeniedInUnwatchedNamespace(t, webhookUnwatchedNamespace)
+		return ctx
+	})
+
+	feature.Assess("CR accepted in watched namespace", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		assertWebhookAllowedInWatchedNamespace(t, webhookWatchedNamespace)
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: webhookUnwatchedNamespace}}
+		if err := client.Resources().Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("warning: failed to delete namespace %s: %v", webhookUnwatchedNamespace, err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func writeTempMarklogicClusterManifest(t *testing.T, namespace, name string) string {
+	t.Helper()
+
+	manifest := fmt.Sprintf(`apiVersion: marklogic.progress.com/v1
+kind: MarklogicCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image: %s
+  auth:
+    adminUsername: %s
+    adminPassword: %s
+  markLogicGroups:
+  - name: node
+    replicas: 1
+    isBootstrap: true
+`, name, namespace, marklogicImage, adminUsername, adminPassword)
+
+	f, err := os.CreateTemp("", "ml-webhook-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp manifest: %v", err)
+	}
+	if _, err := f.WriteString(manifest); err != nil {
+		f.Close()
+		t.Fatalf("failed to write temp manifest: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close temp manifest: %v", err)
+	}
+	return f.Name()
+}
+
+func assertWebhookDeniedInUnwatchedNamespace(t *testing.T, namespace string) {
+	t.Helper()
+
+	manifestPath := writeTempMarklogicClusterManifest(t, namespace, "webhook-denied")
+	defer os.Remove(manifestPath)
+
+	cmd := exec.Command("kubectl", "apply", "--dry-run=server", "-f", manifestPath)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected admission denial for namespace %s, but apply succeeded: %s", namespace, string(output))
+	}
+
+	out := string(output)
+	if !strings.Contains(out, "outside operator watch scope") {
+		t.Fatalf("expected denial message to mention watch scope, got: %s", out)
+	}
+	if !strings.Contains(out, namespace) {
+		t.Fatalf("expected denial message to include namespace %s, got: %s", namespace, out)
+	}
+}
+
+func assertWebhookAllowedInWatchedNamespace(t *testing.T, namespace string) {
+	t.Helper()
+
+	manifestPath := writeTempMarklogicClusterManifest(t, namespace, "webhook-allowed")
+	defer os.Remove(manifestPath)
+
+	cmd := exec.Command("kubectl", "apply", "--dry-run=server", "-f", manifestPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected apply to succeed in watched namespace %s, got error: %v output: %s", namespace, err, string(output))
+	}
+}

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marklogic/marklogic-operator-kubernetes/test/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -57,6 +58,7 @@ var (
 	testEnv        env.Environment
 	dockerImage    = os.Getenv("E2E_DOCKER_IMAGE")
 	marklogicImage = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
+	webhookCerts   = normalizeWebhookCertProvider(os.Getenv("E2E_HELM_WEBHOOK_CERT_PROVIDER"))
 
 	// Shared credentials and container name used across all test files in this package.
 	adminUsername   = "admin"
@@ -167,6 +169,7 @@ func TestMain(m *testing.M) {
 	log.Printf("e2e-helm: docker image: %s", dockerImage)
 	log.Printf("e2e-helm: marklogic image: %s", marklogicImage)
 	log.Printf("e2e-helm: watched namespaces: %s", watchedNamespaces)
+	log.Printf("e2e-helm: webhook cert provider: %s", webhookCerts)
 
 	testEnv.Setup(
 		// Ensure the operator namespace is clean before installing.
@@ -190,6 +193,23 @@ func TestMain(m *testing.M) {
 			return ctx, nil
 		},
 		envfuncs.CreateNamespace(helmNS),
+
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if webhookCerts != "certmanager" {
+				return ctx, nil
+			}
+
+			log.Printf("Installing cert-manager for webhook certManager provider...")
+			if err := utils.InstallCertManager(); err != nil {
+				return ctx, fmt.Errorf("failed to install cert-manager: %w", err)
+			}
+
+			if err := ensureWebhookClusterIssuer(); err != nil {
+				return ctx, err
+			}
+
+			return ctx, nil
+		},
 
 		// Pre-create all watched namespaces so the Helm chart can create
 		// Role/RoleBinding in them during install.
@@ -243,6 +263,12 @@ func TestMain(m *testing.M) {
 				"--set", "metrics.secure=false",
 				"--wait",
 				"--timeout", "3m",
+			}
+			if webhookCerts == "certmanager" {
+				args = append(args,
+					"--set", "webhook.certs.provider=certManager",
+					"--set", "webhook.certs.certManager.enabled=true",
+				)
 			}
 			if dockerImage != "" {
 				// Reject shell metacharacters before incorporating the env var into args.
@@ -299,6 +325,14 @@ func TestMain(m *testing.M) {
 	)
 
 	testEnv.Finish(
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if webhookCerts == "certmanager" {
+				log.Printf("Uninstalling cert-manager...")
+				utils.UninstallCertManager()
+			}
+			return ctx, nil
+		},
+
 		// Uninstall the Helm release.
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 			log.Printf("Uninstalling Helm release %s", helmRelease)
@@ -496,6 +530,42 @@ func cleanupClusterScopedRBACArtifacts() error {
 		if err != nil {
 			return fmt.Errorf("failed deleting ClusterRole %s: %w: %s", name, err, strings.TrimSpace(string(deleteOut)))
 		}
+	}
+
+	return nil
+}
+
+func normalizeWebhookCertProvider(provider string) string {
+	if strings.EqualFold(provider, "certManager") || strings.EqualFold(provider, "certmanager") {
+		return "certmanager"
+	}
+	return "selfsigned"
+}
+
+func ensureWebhookClusterIssuer() error {
+	issuerManifest := `apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: marklogic-operator-selfsigned
+spec:
+  selfSigned: {}
+`
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(issuerManifest)
+	issuerOut, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed creating webhook cluster issuer: %w: %s", err, strings.TrimSpace(string(issuerOut)))
+	}
+
+	waitCmd := exec.Command(
+		"kubectl", "wait", "clusterissuer/marklogic-operator-selfsigned",
+		"--for=condition=Ready",
+		"--timeout=2m",
+	)
+	waitOut, err := waitCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed waiting for webhook cluster issuer readiness: %w: %s", err, strings.TrimSpace(string(waitOut)))
 	}
 
 	return nil


### PR DESCRIPTION
This pull request introduces support for configuring the MarkLogic Operator's admission webhook with either self-signed or cert-manager-provided TLS certificates, and enhances the Helm chart and CI pipeline to support flexible, validated webhook deployment. It also improves the Jenkins pipeline to allow targeted Helm namespace-scoped E2E test runs and adds robust validation for invalid configuration combinations. Several RBAC permissions are adjusted for clarity and correctness.

**Helm chart and webhook enhancements:**

* Added support for both self-signed and cert-manager-managed TLS certificates for the admission webhook, including new Helm templates (`webhook-certs.yaml`, `webhook-service.yaml`) and values to control certificate provider, secret name, and related settings. The deployment now mounts the webhook cert secret and exposes the webhook port. [[1]](diffhunk://#diff-cb71c927d9746e3e453be937706002c55571e202071429253b262505a255f9dfR1-R166) [[2]](diffhunk://#diff-392876578bc9e4a447edcd3e8222ea202c28595c5acadd332d8d80e89b795a42R1-R19) [[3]](diffhunk://#diff-0bcff16627d3db5c019076a3d97f46f5c0dda75f862a2df61bfaa329060d6981R90-R93) [[4]](diffhunk://#diff-0bcff16627d3db5c019076a3d97f46f5c0dda75f862a2df61bfaa329060d6981R104-R107) [[5]](diffhunk://#diff-0bcff16627d3db5c019076a3d97f46f5c0dda75f862a2df61bfaa329060d6981R49-R50) [[6]](diffhunk://#diff-0bcff16627d3db5c019076a3d97f46f5c0dda75f862a2df61bfaa329060d6981R32-R38) [[7]](diffhunk://#diff-0443f2ec36034a6aaa37367b946dac4da8bfe6c9fa273c8bdc51422c6c005b90R56-R84)
* Added Helm template validation to fail fast on invalid combinations of webhook settings (e.g., mismatched provider and certManager.enabled values). [[1]](diffhunk://#diff-8387255bef97fbb2ee1df33fd100f6624a765741ed98ae4955344062c7479964R1-R7) [[2]](diffhunk://#diff-1075edcd15781245a481f60d6985de8e8eb893fc9fac9d7009ba589531398a13R7-R14)

**Jenkins pipeline improvements:**

* Added new pipeline parameters to control Helm namespace-scoped E2E tests, including an opt-in cert-manager variant and a run-only mode for these tests. The pipeline logic now supports running both self-signed and cert-manager variants in one pass if requested, and skips unrelated stages when in run-only mode. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R331-R348) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R362-R364) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L413-R424) [[4]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L422-R474) [[5]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R486-R502) [[6]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L230-R232)

**RBAC and permissions:**

* Refactored RBAC rules for `persistentvolumeclaims` and `events` to clarify verbs and avoid duplication, aligning with best practices. [[1]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035L13) [[2]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035R25-R49) [[3]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035L88-L96) [[4]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035L161) [[5]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035R182-R206) [[6]](diffhunk://#diff-a58e82c761020f2c2678401e4a1af34498ac9d7dd6501a7f508a6cbf83145035L236-L244)

These changes make the webhook setup more robust, flexible, and CI-friendly, and ensure that invalid configurations are caught early.