### PR TITLE
MLE-31044: Automate operator upgrade testing for 1.3.0 and future release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,21 @@ void runMinikubeSetup() {
     """
 }
 
-void runE2eTests(String scope = 'cluster') {
+void runE2eTests(String scope = 'cluster', String installMode = 'fresh') {
+    if (!(installMode in ['fresh', 'upgrade'])) {
+        error "Unsupported E2E install mode '${installMode}'. Supported modes: fresh, upgrade"
+    }
+
+    if (installMode == 'upgrade') {
+        if (scope != 'cluster') {
+            error "Upgrade e2e flow only supports E2E_SCOPE='cluster'."
+        }
+        sh """
+            make e2e-test-upgrade-cluster IMG=${operatorRepo}:${VERSION}
+        """
+        return
+    }
+
     if (!(scope in ['cluster', 'dynamic-host', 'volume-resize'])) {
         error "Unsupported E2E scope '${scope}'. Supported scopes: cluster, dynamic-host, volume-resize"
     }
@@ -227,7 +241,18 @@ void runEKSIstioE2eTests() {
     }
 }
 
-void runHelmNamespaceScopedE2eTests() {
+void runHelmNamespaceScopedE2eTests(String installMode = 'fresh') {
+    if (!(installMode in ['fresh', 'upgrade'])) {
+        error "Unsupported E2E install mode '${installMode}'. Supported modes: fresh, upgrade"
+    }
+
+    if (installMode == 'upgrade') {
+        sh """
+            make e2e-test-upgrade-helm-namespace IMG=${operatorRepo}:${VERSION}
+        """
+        return
+    }
+
     sh """
         make e2e-test-helm-namespace IMG=${operatorRepo}:${VERSION}
     """
@@ -321,6 +346,7 @@ pipeline {
     parameters {
         string(name: 'E2E_MARKLOGIC_IMAGE_VERSION', defaultValue: 'ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-ubi-rootless:latest-12', description: 'Docker image to use for tests.', trim: true)
         string(name: 'VERSION', defaultValue: '1.2.0', description: 'Version to tag the image with.', trim: true)
+        choice(name: 'E2E_INSTALL_MODE', choices: ['fresh', 'upgrade'], description: 'Run the standard fresh-install e2e flow or the upgrade validation flow. Default is fresh.')
         choice(name: 'E2E_SCOPE', choices: ['cluster', 'dynamic-host', 'volume-resize'], description: 'E2E scope for Minikube runs. Use cluster for full suite; dynamic-host and volume-resize run focused targets.')
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
@@ -357,8 +383,17 @@ pipeline {
                         error "E2E_SCOPE='${params.E2E_SCOPE}' is not supported when TEST_ON_EKS=true. Use E2E_SCOPE='cluster'."
                     }
 
+                    if (params.E2E_INSTALL_MODE == 'upgrade') {
+                        if (params.TEST_ON_EKS) {
+                            error "E2E_INSTALL_MODE='upgrade' is only supported on the Minikube path right now. Use TEST_ON_EKS=false."
+                        }
+                        if (params.E2E_SCOPE != 'cluster') {
+                            error "E2E_INSTALL_MODE='upgrade' requires E2E_SCOPE='cluster'."
+                        }
+                    }
+
                     def doSetup    = { params.TEST_ON_EKS ? runEKSSetup()          : runMinikubeSetup() }
-                    def doTests    = { params.TEST_ON_EKS ? runEKSE2eTests()        : runE2eTests(params.E2E_SCOPE) }
+                    def doTests    = { params.TEST_ON_EKS ? runEKSE2eTests()        : runE2eTests(params.E2E_SCOPE, params.E2E_INSTALL_MODE) }
                     def doCleanup  = {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                             if (params.TEST_ON_EKS) { runEKSCleanup() } else { runMinikubeCleanup() }
@@ -380,17 +415,17 @@ pipeline {
                         // immediately skipped, preserving their position in the view.
                         try {
                             stage('Istio Setup') {
-                                if (params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doIstioSetup() }
-                                else { echo "Istio tests skipped (E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
+                                if (params.E2E_INSTALL_MODE == 'fresh' && params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doIstioSetup() }
+                                else { echo "Istio tests skipped (E2E_INSTALL_MODE=${params.E2E_INSTALL_MODE}, E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
                             }
                             stage('Run Istio e2e Tests') {
-                                if (params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doIstioTests() }
-                                else { echo "Istio tests skipped (E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
+                                if (params.E2E_INSTALL_MODE == 'fresh' && params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doIstioTests() }
+                                else { echo "Istio tests skipped (E2E_INSTALL_MODE=${params.E2E_INSTALL_MODE}, E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
                             }
                         } finally {
                             stage('Istio Cleanup') {
-                                if (params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doCleanup() }
-                                else { echo "Istio tests skipped (E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
+                                if (params.E2E_INSTALL_MODE == 'fresh' && params.E2E_SCOPE == 'cluster' && params.VERIFY_ISTIO_AMBIENT) { doCleanup() }
+                                else { echo "Istio tests skipped (E2E_INSTALL_MODE=${params.E2E_INSTALL_MODE}, E2E_SCOPE=${params.E2E_SCOPE}, VERIFY_ISTIO_AMBIENT=${params.VERIFY_ISTIO_AMBIENT})" }
                             }
                         }
                     }
@@ -422,7 +457,7 @@ pipeline {
                 expression { return params.VERIFY_HELM_NAMESPACE_SCOPED != false && params.E2E_SCOPE == 'cluster' }
             }
             steps {
-                runHelmNamespaceScopedE2eTests()
+                runHelmNamespaceScopedE2eTests(params.E2E_INSTALL_MODE)
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ export FLUENT_BIT_IMAGE ?= fluent/fluent-bit:4.1.1
 export E2E_KUBERNETES_VERSION ?= v1.31.13
 export E2E_ISTIO_AMBIENT ?= false
 export E2E_TEST_TIMEOUT ?= 60m
+export E2E_HELM_TEST_TIMEOUT ?= 45m
+E2E_UPGRADE_SOURCE_VERSION ?= 1.2.0
+E2E_UPGRADE_CLUSTER_TEST_TIMEOUT ?= 90m
+E2E_UPGRADE_HELM_NAMESPACE_TEST_TIMEOUT ?= 75m
+E2E_UPGRADE_CLEANUP_TIMEOUT ?= 15m
 
 # EKS / ECR configuration for Jenkins EKS test environment.
 # Set AWS_ACCOUNT_ID in the environment (or pass on the make command line).
@@ -232,6 +237,45 @@ e2e-test-helm-namespace:
 		echo "=====Current context is not minikube; skipping image load====="; \
 	fi
 	E2E_DOCKER_IMAGE=$(IMG) go test -v -count=1 -timeout 45m ./test/e2e-helm
+
+.PHONY: e2e-test-upgrade  ## Run both upgrade validation scenarios (cluster + namespace) and then reuse the matching e2e suites.
+e2e-test-upgrade:
+	@$(MAKE) e2e-test-upgrade-cluster IMG=$(IMG)
+	@$(MAKE) e2e-test-upgrade-helm-namespace IMG=$(IMG)
+
+.PHONY: e2e-test-upgrade-cluster  ## Run the cluster-scoped upgrade validation and then reuse the cluster-scoped e2e suite.
+e2e-test-upgrade-cluster:
+	@echo "=====Running cluster-scoped upgrade validation====="
+	@if kubectl config current-context 2>/dev/null | grep -q '^minikube$$'; then \
+		echo "=====Loading operator image $(IMG) into minikube====="; \
+		minikube image load $(IMG); \
+	else \
+		echo "=====Current context is not minikube; skipping image load====="; \
+	fi
+	E2E_UPGRADE_SOURCE_VERSION=$(E2E_UPGRADE_SOURCE_VERSION) \
+	E2E_UPGRADE_TARGET_IMAGE=$(IMG) \
+	E2E_MARKLOGIC_IMAGE_VERSION=$(E2E_MARKLOGIC_IMAGE_VERSION) \
+	go test -tags upgradee2e -v -count=1 -timeout $(E2E_UPGRADE_CLUSTER_TEST_TIMEOUT) ./test -run '^TestUpgradeClusterScope$$'
+
+.PHONY: e2e-test-upgrade-helm-namespace  ## Run the namespace-scoped upgrade validation and then reuse the Helm namespace-scoped e2e suite.
+e2e-test-upgrade-helm-namespace:
+	@echo "=====Running namespace-scoped upgrade validation====="
+	@if kubectl config current-context 2>/dev/null | grep -q '^minikube$$'; then \
+		echo "=====Loading operator image $(IMG) into minikube====="; \
+		minikube image load $(IMG); \
+	else \
+		echo "=====Current context is not minikube; skipping image load====="; \
+	fi
+	E2E_UPGRADE_SOURCE_VERSION=$(E2E_UPGRADE_SOURCE_VERSION) \
+	E2E_UPGRADE_TARGET_IMAGE=$(IMG) \
+	E2E_MARKLOGIC_IMAGE_VERSION=$(E2E_MARKLOGIC_IMAGE_VERSION) \
+	go test -tags upgradee2e -v -count=1 -timeout $(E2E_UPGRADE_HELM_NAMESPACE_TEST_TIMEOUT) ./test -run '^TestUpgradeNamespaceScope$$'
+
+.PHONY: e2e-test-upgrade-cleanup  ## Delete upgrade-test releases and namespaces, optionally filtered by E2E_UPGRADE_RUN_ID.
+e2e-test-upgrade-cleanup:
+	@echo "=====Cleaning upgrade-test resources====="
+	E2E_UPGRADE_RUN_ID=$(E2E_UPGRADE_RUN_ID) \
+	go test -tags upgradee2e -v -count=1 -timeout $(E2E_UPGRADE_CLEANUP_TIMEOUT) ./test -run '^TestCleanupUpgradeResources$$'
 
 .PHONY: e2e-test-volume-resize  ## Run ONLY the cluster-scoped volume resize test (two namespaces in parallel)
 e2e-test-volume-resize:

--- a/config/samples/dynamic-host.yaml
+++ b/config/samples/dynamic-host.yaml
@@ -1,0 +1,20 @@
+apiVersion: marklogic.progress.com/v1
+kind: MarklogicCluster
+metadata:
+  name: ml-dynamic-host
+  namespace: ml-dynamic-host
+spec:
+  image: "progressofficial/marklogic-db:12.0.0-ubi9-rootless-2.2.2"
+  markLogicGroups:
+  - name: bootstrap
+    isBootstrap: true
+    replicas: 1
+    groupConfig:
+      name: bootstrap
+  - name: dynamic
+    isDynamic: true
+    dynamic:
+      tokenDuration: PT15M
+    replicas: 1
+    groupConfig:
+      name: dynamic

--- a/test/e2e-helm/main_test.go
+++ b/test/e2e-helm/main_test.go
@@ -39,11 +39,17 @@ import (
 	e2eutils "sigs.k8s.io/e2e-framework/pkg/utils"
 )
 
-// helmNS is the namespace the operator is installed into.
-const helmNS = "marklogic-operator-system"
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+var helmNS = envOrDefault("E2E_OPERATOR_NAMESPACE", "marklogic-operator-system")
 
 // helmRelease is the Helm release name used for install/uninstall.
-const helmRelease = "marklogic-operator"
+var helmRelease = envOrDefault("E2E_OPERATOR_RELEASE", "marklogic-operator")
 
 // helmChart is the path to the local chart (relative to repo root, where make runs).
 const helmChart = "charts/marklogic-operator-kubernetes"
@@ -51,12 +57,13 @@ const helmChart = "charts/marklogic-operator-kubernetes"
 // watchedNamespaces is the comma-separated list of namespaces the operator watches.
 // Every test namespace in this suite must appear here — the namespace-scoped operator
 // only has a Role/RoleBinding in these namespaces (no ClusterRole backstop).
-const watchedNamespaces = "ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log,ml-ns-resize-a,ml-ns-resize-b"
+var watchedNamespaces = envOrDefault("E2E_WATCHED_NAMESPACES", "ml-ns-test,ml-ns-ednode,ml-ns-tls,ml-ns-tls-named,ml-ns-tls-ednode,ml-ns-haproxy-path,ml-ns-haproxy,ml-ns-log,ml-ns-resize-a,ml-ns-resize-b")
 
 var (
-	testEnv        env.Environment
-	dockerImage    = os.Getenv("E2E_DOCKER_IMAGE")
-	marklogicImage = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
+	testEnv             env.Environment
+	dockerImage         = os.Getenv("E2E_DOCKER_IMAGE")
+	marklogicImage      = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
+	useExistingOperator = strings.EqualFold(os.Getenv("E2E_USE_EXISTING_OPERATOR"), "true")
 
 	// Shared credentials and container name used across all test files in this package.
 	adminUsername   = "admin"
@@ -167,10 +174,16 @@ func TestMain(m *testing.M) {
 	log.Printf("e2e-helm: docker image: %s", dockerImage)
 	log.Printf("e2e-helm: marklogic image: %s", marklogicImage)
 	log.Printf("e2e-helm: watched namespaces: %s", watchedNamespaces)
+	log.Printf("e2e-helm: operator namespace: %s", helmNS)
+	log.Printf("e2e-helm: reuse existing operator install: %v", useExistingOperator)
 
 	testEnv.Setup(
 		// Ensure the operator namespace is clean before installing.
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				log.Printf("Reusing existing operator namespace: %s", helmNS)
+				return ctx, nil
+			}
 			log.Printf("Ensuring clean operator namespace: %s", helmNS)
 			client := cfg.Client()
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: helmNS}}
@@ -189,7 +202,12 @@ func TestMain(m *testing.M) {
 			}
 			return ctx, nil
 		},
-		envfuncs.CreateNamespace(helmNS),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
+			return envfuncs.CreateNamespace(helmNS)(ctx, cfg)
+		},
 
 		// Pre-create all watched namespaces so the Helm chart can create
 		// Role/RoleBinding in them during install.
@@ -220,6 +238,10 @@ func TestMain(m *testing.M) {
 		// scope.type=namespace  → Role/RoleBinding per watched namespace (no ClusterRole)
 		// metrics.secure=false  → HTTP :8080 (ClusterRole for TokenReview not available)
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				log.Printf("Reusing existing operator installation in namespace %s", helmNS)
+				return ctx, nil
+			}
 			log.Printf("Installing operator via Helm (scope=namespace, metrics.secure=false)...")
 
 			if err := resetMarkLogicCRDsForHelmInstall(); err != nil {
@@ -301,6 +323,9 @@ func TestMain(m *testing.M) {
 	testEnv.Finish(
 		// Uninstall the Helm release.
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
 			log.Printf("Uninstalling Helm release %s", helmRelease)
 			// #nosec G204 — helmRelease and helmNS are package constants
 			cmd := exec.Command("helm", "uninstall", helmRelease, "--namespace", helmNS, "--ignore-not-found")
@@ -311,10 +336,18 @@ func TestMain(m *testing.M) {
 			}
 			return ctx, nil
 		},
-		envfuncs.DeleteNamespace(helmNS),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
+			return envfuncs.DeleteNamespace(helmNS)(ctx, cfg)
+		},
 
 		// Delete all watched namespaces created during Setup.
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
 			client := cfg.Client()
 			for _, ns := range strings.Split(watchedNamespaces, ",") {
 				if err := client.Resources().Delete(ctx, &corev1.Namespace{

--- a/test/e2e/8_metrics_test.go
+++ b/test/e2e/8_metrics_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -253,7 +254,8 @@ func TestMetricsEndpoint(t *testing.T) {
 			restCfg := c.Client().RESTConfig()
 			// Use the operator controller-manager SA — it has many permissions but
 			// is NOT bound to the metrics-reader ClusterRole, so the SAR check must deny it.
-			token := requestSAToken(ctx, t, restCfg, namespace, "marklogic-operator-controller-manager")
+			operatorSA := operatorServiceAccountName(ctx, t, c, namespace)
+			token := requestSAToken(ctx, t, restCfg, namespace, operatorSA)
 
 			pf, localAddr, cancel := startPortForward(t, namespace, metricsServiceName, localPort, remotePort)
 			defer func() {
@@ -377,4 +379,20 @@ func requestSAToken(ctx context.Context, t *testing.T, cfg *rest.Config, ns, saN
 		t.Fatalf("failed to obtain token for ServiceAccount %s/%s: %v", ns, saName, err)
 	}
 	return result.Status.Token
+}
+
+func operatorServiceAccountName(ctx context.Context, t *testing.T, c *envconf.Config, ns string) string {
+	t.Helper()
+
+	deployment := &appsv1.Deployment{}
+	if err := c.Client().Resources().Get(ctx, "marklogic-operator-controller-manager", ns, deployment); err != nil {
+		t.Fatalf("failed to get operator deployment in namespace %s: %v", ns, err)
+	}
+
+	serviceAccountName := strings.TrimSpace(deployment.Spec.Template.Spec.ServiceAccountName)
+	if serviceAccountName == "" {
+		return "default"
+	}
+
+	return serviceAccountName
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,12 +31,15 @@ import (
 )
 
 var (
-	testEnv        env.Environment
-	dockerImage    = os.Getenv("E2E_DOCKER_IMAGE")
-	kustomizeVer   = os.Getenv("E2E_KUSTOMIZE_VERSION")
-	ctrlgenVer     = os.Getenv("E2E_CONTROLLER_TOOLS_VERSION")
-	marklogicImage = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
-	kubernetesVer  = os.Getenv("E2E_KUBERNETES_VERSION")
+	testEnv             env.Environment
+	dockerImage         = os.Getenv("E2E_DOCKER_IMAGE")
+	kustomizeVer        = os.Getenv("E2E_KUSTOMIZE_VERSION")
+	ctrlgenVer          = os.Getenv("E2E_CONTROLLER_TOOLS_VERSION")
+	marklogicImage      = os.Getenv("E2E_MARKLOGIC_IMAGE_VERSION")
+	kubernetesVer       = os.Getenv("E2E_KUBERNETES_VERSION")
+	operatorNamespace   = envOrDefault("E2E_OPERATOR_NAMESPACE", "marklogic-operator-system")
+	namespace           = operatorNamespace
+	useExistingOperator = strings.EqualFold(os.Getenv("E2E_USE_EXISTING_OPERATOR"), "true")
 
 	staleE2ENamespaces = []string{
 		"ml-dynamic-host",
@@ -56,8 +59,6 @@ var (
 )
 
 const (
-	namespace = "marklogic-operator-system"
-
 	// Keep CRD cleanup fast in local/CI e2e loops: do a short grace wait first,
 	// then escalate quickly to finalizer cleanup when termination is stuck.
 	// On minikube, CRD terminating/finalizer transitions can take noticeably
@@ -67,6 +68,13 @@ const (
 	crdCleanupPostFinalizeWaitAttempts = 90
 	crdCleanupPostFinalizeWaitInterval = 2 * time.Second
 )
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
 
 // namespaceLabels returns the labels to apply to test namespaces.
 // When Istio ambient mode is enabled, includes the ambient dataplane label.
@@ -169,20 +177,26 @@ func TestMain(m *testing.M) {
 	log.Printf("MarkLogic image: %s", marklogicImage)
 	log.Printf("Kubernetes version: %s", kubernetesVer)
 	log.Printf("Istio ambient mode: %v", isIstioAmbientEnabled())
+	log.Printf("Operator namespace: %s", operatorNamespace)
+	log.Printf("Reuse existing operator install: %v", useExistingOperator)
 
 	// Use Environment.Setup to configure pre-test setup
 	testEnv.Setup(
 		// Delete namespace if it exists from previous run
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-			log.Printf("Ensuring clean namespace: %s", namespace)
+			if useExistingOperator {
+				log.Printf("Reusing existing operator namespace: %s", operatorNamespace)
+				return ctx, nil
+			}
+			log.Printf("Ensuring clean namespace: %s", operatorNamespace)
 			client := cfg.Client()
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorNamespace}}
 
 			// Try to get the namespace first
-			err := client.Resources().Get(ctx, namespace, "", ns)
+			err := client.Resources().Get(ctx, operatorNamespace, "", ns)
 			if err == nil {
 				// Namespace exists, delete it
-				log.Printf("Deleting existing namespace: %s", namespace)
+				log.Printf("Deleting existing namespace: %s", operatorNamespace)
 				if err := client.Resources().Delete(ctx, ns); err != nil {
 					log.Printf("Error deleting namespace (may already be deleting): %v", err)
 				}
@@ -190,7 +204,7 @@ func TestMain(m *testing.M) {
 				// Wait for namespace to be fully deleted (up to 60 seconds)
 				log.Printf("Waiting for namespace deletion to complete...")
 				for i := 0; i < 60; i++ {
-					err := client.Resources().Get(ctx, namespace, "", ns)
+					err := client.Resources().Get(ctx, operatorNamespace, "", ns)
 					if err != nil {
 						if apierrors.IsNotFound(err) {
 							// Namespace is gone
@@ -201,14 +215,14 @@ func TestMain(m *testing.M) {
 						return ctx, fmt.Errorf("error checking namespace deletion status: %w", err)
 					}
 					if i == 59 {
-						log.Printf("Namespace %s still deleting after initial wait; forcing namespace finalizer cleanup", namespace)
-						if err := forceFinalizeNamespace(namespace); err != nil {
-							return ctx, fmt.Errorf("timeout waiting for namespace %s to be deleted; force-finalize failed: %w", namespace, err)
+						log.Printf("Namespace %s still deleting after initial wait; forcing namespace finalizer cleanup", operatorNamespace)
+						if err := forceFinalizeNamespace(operatorNamespace); err != nil {
+							return ctx, fmt.Errorf("timeout waiting for namespace %s to be deleted; force-finalize failed: %w", operatorNamespace, err)
 						}
-						if err := waitForNamespaceDeletionByName(ctx, client, namespace, 90*time.Second); err != nil {
+						if err := waitForNamespaceDeletionByName(ctx, client, operatorNamespace, 90*time.Second); err != nil {
 							return ctx, err
 						}
-						log.Printf("Namespace %s force-deleted successfully", namespace)
+						log.Printf("Namespace %s force-deleted successfully", operatorNamespace)
 						break
 					}
 					time.Sleep(1 * time.Second)
@@ -223,7 +237,12 @@ func TestMain(m *testing.M) {
 
 			return ctx, nil
 		},
-		envfuncs.CreateNamespace(namespace),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
+			return envfuncs.CreateNamespace(operatorNamespace)(ctx, cfg)
+		},
 
 		// Ensure stale namespaces from interrupted prior runs do not cause
 		// namespace-already-exists conflicts in individual tests.
@@ -236,6 +255,9 @@ func TestMain(m *testing.M) {
 
 		// When Istio ambient mode is enabled, label the operator namespace
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
 			if !isIstioAmbientEnabled() {
 				return ctx, nil
 			}
@@ -244,7 +266,7 @@ func TestMain(m *testing.M) {
 
 			// Patch the operator namespace to add the ambient label
 			operatorNs := &corev1.Namespace{}
-			if err := client.Resources().Get(ctx, namespace, "", operatorNs); err != nil {
+			if err := client.Resources().Get(ctx, operatorNamespace, "", operatorNs); err != nil {
 				return ctx, fmt.Errorf("failed to get operator namespace: %w", err)
 			}
 
@@ -253,7 +275,7 @@ func TestMain(m *testing.M) {
 			if err := client.Resources().Patch(ctx, operatorNs, k8s.Patch{PatchType: types.StrategicMergePatchType, Data: patchData}); err != nil {
 				return ctx, fmt.Errorf("failed to label operator namespace: %w", err)
 			}
-			log.Printf("Labeled namespace %s with istio.io/dataplane-mode=ambient", namespace)
+			log.Printf("Labeled namespace %s with istio.io/dataplane-mode=ambient", operatorNamespace)
 
 			return ctx, nil
 		},
@@ -327,6 +349,20 @@ func TestMain(m *testing.M) {
 
 		// generate and deploy resource configurations
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				log.Println("Reusing existing operator installation; skipping deploy")
+				client := cfg.Client()
+				if err := wait.For(
+					conditions.New(client.Resources()).DeploymentConditionMatch(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "marklogic-operator-controller-manager", Namespace: operatorNamespace}},
+						appsv1.DeploymentAvailable,
+						corev1.ConditionTrue),
+					wait.WithTimeout(3*time.Minute),
+					wait.WithInterval(10*time.Second),
+				); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			}
 			log.Println("Building source components...")
 
 			log.Println("Cleaning stale MarkLogic custom resources before deploy...")
@@ -351,10 +387,10 @@ func TestMain(m *testing.M) {
 				// If it disappeared or is Terminating (concurrent cleanup), wait and recreate.
 				for i := 0; i < 60; i++ {
 					ns := &corev1.Namespace{}
-					nsErr := client.Resources().Get(ctx, namespace, "", ns)
+					nsErr := client.Resources().Get(ctx, operatorNamespace, "", ns)
 					if apierrors.IsNotFound(nsErr) {
-						log.Printf("Namespace %s not found before deploy attempt %d; recreating", namespace, attempt)
-						newNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+						log.Printf("Namespace %s not found before deploy attempt %d; recreating", operatorNamespace, attempt)
+						newNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorNamespace}}
 						_ = client.Resources().Create(ctx, newNs)
 						time.Sleep(2 * time.Second)
 						continue
@@ -364,7 +400,7 @@ func TestMain(m *testing.M) {
 						continue
 					}
 					if ns.Status.Phase == corev1.NamespaceTerminating || ns.DeletionTimestamp != nil {
-						log.Printf("Namespace %s is Terminating before deploy attempt %d; waiting...", namespace, attempt)
+						log.Printf("Namespace %s is Terminating before deploy attempt %d; waiting...", operatorNamespace, attempt)
 						time.Sleep(2 * time.Second)
 						continue
 					}
@@ -401,7 +437,7 @@ func TestMain(m *testing.M) {
 			// wait for controller-manager to be ready
 			log.Println("Waiting for controller-manager deployment to be available...")
 			if err := wait.For(
-				conditions.New(client.Resources()).DeploymentConditionMatch(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "marklogic-operator-controller-manager", Namespace: namespace}},
+				conditions.New(client.Resources()).DeploymentConditionMatch(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "marklogic-operator-controller-manager", Namespace: operatorNamespace}},
 					appsv1.DeploymentProgressing,
 					corev1.ConditionTrue),
 				wait.WithTimeout(3*time.Minute),
@@ -422,6 +458,9 @@ func TestMain(m *testing.M) {
 	testEnv.Finish(
 		// Clean up Istio ambient label from operator namespace
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
 			if !isIstioAmbientEnabled() {
 				return ctx, nil
 			}
@@ -431,14 +470,14 @@ func TestMain(m *testing.M) {
 
 			// Remove label from operator namespace using Patch to avoid conflicts
 			operatorNs := &corev1.Namespace{}
-			if err := client.Resources().Get(ctx, namespace, "", operatorNs); err == nil {
+			if err := client.Resources().Get(ctx, operatorNamespace, "", operatorNs); err == nil {
 				if operatorNs.Labels != nil && operatorNs.Labels["istio.io/dataplane-mode"] != "" {
 					// Use Patch to remove label, avoiding resourceVersion conflicts
 					patchData := []byte(`{"metadata":{"labels":{"istio.io/dataplane-mode":null}}}`)
 					if err := client.Resources().Patch(ctx, operatorNs, k8s.Patch{PatchType: types.StrategicMergePatchType, Data: patchData}); err != nil {
 						log.Printf("Warning: failed to remove label from operator namespace: %v", err)
 					} else {
-						log.Printf("Removed Istio ambient label from %s namespace", namespace)
+						log.Printf("Removed Istio ambient label from %s namespace", operatorNamespace)
 					}
 				}
 			} else if !apierrors.IsNotFound(err) {
@@ -448,6 +487,9 @@ func TestMain(m *testing.M) {
 			return ctx, nil
 		},
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
 			log.Println("Finishing tests, cleaning cluster ...")
 			if err := forceDeleteMarkLogicCustomResources(); err != nil {
 				log.Printf("Warning: failed to force-delete MarkLogic custom resources during cleanup: %v", err)
@@ -456,6 +498,12 @@ func TestMain(m *testing.M) {
 			return ctx, nil
 		},
 		envfuncs.DeleteNamespace(namespace),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			if useExistingOperator {
+				return ctx, nil
+			}
+			return envfuncs.DeleteNamespace(operatorNamespace)(ctx, cfg)
+		},
 	)
 
 	// Use Environment.Run to launch the test

--- a/test/upgrade_e2e_test.go
+++ b/test/upgrade_e2e_test.go
@@ -1,0 +1,876 @@
+//go:build upgradee2e
+
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package upgradee2e
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	defaultSourceChart          = "marklogic-operator/marklogic-operator-kubernetes"
+	defaultSourceVersion        = "1.2.0"
+	defaultTargetChart          = "charts/marklogic-operator-kubernetes"
+	defaultMarkLogicImage       = "progressofficial/marklogic-db:12.0.0-ubi9-rootless-2.2.2"
+	defaultHelmTimeout          = "10m"
+	defaultWorkloadWaitTimeout  = 25 * time.Minute
+	defaultClusterSuiteTimeout  = "60m"
+	defaultNamespaceSuiteTimeout = "45m"
+	defaultOperatorDeployment   = "marklogic-operator-controller-manager"
+
+	cleanupProbeSleep = 30 * time.Second
+)
+
+var (
+	operatorClusterRoles = []string{
+		"marklogic-operator-manager-role",
+		"marklogic-operator-metrics-auth-role",
+		"marklogic-operator-metrics-reader",
+	}
+
+	operatorClusterRoleBindings = []string{
+		"marklogic-operator-manager-rolebinding",
+		"marklogic-operator-metrics-auth-rolebinding",
+	}
+
+	e2eHelmWatchedNamespaces = []string{
+		"ml-ns-test",
+		"ml-ns-ednode",
+		"ml-ns-tls",
+		"ml-ns-tls-named",
+		"ml-ns-tls-ednode",
+		"ml-ns-haproxy-path",
+		"ml-ns-haproxy",
+		"ml-ns-log",
+		"ml-ns-resize-a",
+		"ml-ns-resize-b",
+	}
+
+	e2eClusterCleanupNamespaces = []string{
+		"ml-dynamic-host",
+		"ml-cluster-test",
+		"ednode",
+		"tls-self-signed",
+		"marklogic-tlsnamed",
+		"marklogic-tlsednode",
+		"haproxy-pathbased",
+		"haproxy-test",
+		"log-test",
+		"ml-resize-a",
+		"ml-resize-b",
+		"loki",
+		"grafana",
+	}
+
+	e2eHelmCleanupNamespaces = []string{
+		"ml-ns-test",
+		"ml-ns-ednode",
+		"ml-ns-tls",
+		"ml-ns-tls-named",
+		"ml-ns-tls-ednode",
+		"ml-ns-haproxy-path",
+		"ml-ns-haproxy",
+		"ml-ns-log",
+		"ml-ns-resize-a",
+		"ml-ns-resize-b",
+	}
+
+	marklogicCRDs = []string{
+		"marklogicclusters.marklogic.progress.com",
+		"marklogicgroups.marklogic.progress.com",
+	}
+)
+
+type chartValues struct {
+	ControllerManager struct {
+		Manager struct {
+			Image struct {
+				Repository string `yaml:"repository"`
+				Tag        string `yaml:"tag"`
+			} `yaml:"image"`
+		} `yaml:"manager"`
+	} `yaml:"controllerManager"`
+}
+
+type scenarioState struct {
+	name              string
+	release           string
+	operatorNamespace string
+	namespaces        []string
+}
+
+type upgradeRunner struct {
+	testingT              *testing.T
+	repoRoot              string
+	sourceChart           string
+	sourceVersion         string
+	targetChart           string
+	targetImageRef        string
+	targetImageRepository string
+	targetImageTag        string
+	targetImageFromChart  bool
+	marklogicImage        string
+	helmTimeout           string
+	workloadWaitTimeout   time.Duration
+	clusterSuiteTimeout   string
+	namespaceSuiteTimeout string
+	keepResources         bool
+	skipHelmRepoUpdate    bool
+	runID                 string
+	current               scenarioState
+}
+
+func TestUpgradeClusterScope(t *testing.T) {
+	runner := newUpgradeRunner(t)
+	runner.runClusterUpgradeScenario()
+}
+
+func TestUpgradeNamespaceScope(t *testing.T) {
+	runner := newUpgradeRunner(t)
+	runner.runNamespaceUpgradeScenario()
+}
+
+func TestCleanupUpgradeResources(t *testing.T) {
+	runner := newUpgradeRunner(t)
+	runner.cleanupUpgradeTestResources()
+}
+
+func newUpgradeRunner(t *testing.T) *upgradeRunner {
+	t.Helper()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	runner := &upgradeRunner{
+		testingT:              t,
+		repoRoot:              repoRoot,
+		sourceChart:           envOrDefault("E2E_UPGRADE_SOURCE_CHART", defaultSourceChart),
+		sourceVersion:         envOrDefault("E2E_UPGRADE_SOURCE_VERSION", defaultSourceVersion),
+		targetChart:           envOrDefault("E2E_UPGRADE_TARGET_CHART", defaultTargetChart),
+		marklogicImage:        envOrDefault("E2E_MARKLOGIC_IMAGE_VERSION", defaultMarkLogicImage),
+		helmTimeout:           envOrDefault("E2E_UPGRADE_HELM_TIMEOUT", defaultHelmTimeout),
+		workloadWaitTimeout:   durationEnvOrDefault("E2E_UPGRADE_WORKLOAD_TIMEOUT", defaultWorkloadWaitTimeout),
+		clusterSuiteTimeout:   envOrDefault("E2E_TEST_TIMEOUT", defaultClusterSuiteTimeout),
+		namespaceSuiteTimeout: envOrDefault("E2E_HELM_TEST_TIMEOUT", defaultNamespaceSuiteTimeout),
+		keepResources:         boolEnv("E2E_UPGRADE_KEEP_RESOURCES"),
+		skipHelmRepoUpdate:    boolEnv("E2E_UPGRADE_SKIP_HELM_REPO_UPDATE"),
+		runID:                 os.Getenv("E2E_UPGRADE_RUN_ID"),
+	}
+
+	runner.targetImageRef = envOrDefault("E2E_UPGRADE_TARGET_IMAGE", os.Getenv("E2E_DOCKER_IMAGE"))
+
+	return runner
+}
+
+func (r *upgradeRunner) runClusterUpgradeScenario() {
+	r.requireTools("kubectl", "helm")
+	r.parseTargetImage()
+	r.ensureRunID()
+	r.ensureHelmRepo()
+	r.verifyClusterIsClean()
+	r.verifyChartInputs()
+	r.verifyDefaultTargetImageAvailable()
+
+	operatorNamespace := "mlop-upg-cluster-" + r.runID
+	baselineNamespace := "ml-upg-base-" + r.runID
+	postNamespace := "ml-upg-post-" + r.runID
+	release := "mlop-upg-cluster-" + r.runID
+
+	r.registerScenario("cluster", release, operatorNamespace, operatorNamespace, baselineNamespace, postNamespace)
+	r.enableFailureDiagnosticsAndCleanup()
+
+	r.testingT.Logf("Starting cluster-scope upgrade scenario with run-id %s", r.runID)
+	r.createNamespace(operatorNamespace)
+	r.createNamespace(baselineNamespace)
+	r.createNamespace(postNamespace)
+	r.adoptExistingCRDsForRelease(release, operatorNamespace)
+
+	r.runCommand("helm", "upgrade", "--install", release, r.sourceChart,
+		"--version", r.sourceVersion,
+		"--namespace", operatorNamespace,
+		"--create-namespace",
+		"--wait",
+		"--timeout", r.helmTimeout,
+	)
+
+	r.waitForOperatorReady(operatorNamespace)
+	r.deployMarkLogicCluster(baselineNamespace, "ml-upgrade-baseline")
+
+	r.runCommand("helm", r.buildTargetUpgradeArgs(release, operatorNamespace, "cluster", "")...)
+	r.waitForOperatorReady(operatorNamespace)
+
+	r.assertClusterResourcePresent("clusterrole", "marklogic-operator-manager-role")
+	r.assertClusterResourcePresent("clusterrolebinding", "marklogic-operator-manager-rolebinding")
+
+	argsString := r.deploymentArgs(operatorNamespace)
+	r.assertContains(argsString, "--metrics-secure=true", "cluster-scope metrics must stay secure after upgrade")
+	r.assertContains(argsString, "--metrics-bind-address=:8443", "cluster-scope metrics port must stay at 8443")
+	r.assertNotContains(argsString, "--metrics-secure=false", "cluster-scope deployment args are incorrect")
+
+	r.waitForPodReady(baselineNamespace, "node-0")
+	r.deployMarkLogicCluster(postNamespace, "ml-upgrade-post")
+
+	r.appendCurrentNamespaces(e2eClusterCleanupNamespaces...)
+	r.runClusterE2ESuite()
+
+	r.testingT.Log("Cluster-scope upgrade scenario passed")
+}
+
+func (r *upgradeRunner) runNamespaceUpgradeScenario() {
+	r.requireTools("kubectl", "helm")
+	r.parseTargetImage()
+	r.ensureRunID()
+	r.ensureHelmRepo()
+	r.verifyClusterIsClean()
+	r.verifyChartInputs()
+	r.verifyDefaultTargetImageAvailable()
+
+	operatorNamespace := "mlop-upg-ns-" + r.runID
+	primaryWatchedNamespace := "ml-upg-watch-a-" + r.runID
+	secondaryWatchedNamespace := "ml-upg-watch-b-" + r.runID
+	unwatchedNamespace := "ml-upg-unwatched-" + r.runID
+	release := "mlop-upg-ns-" + r.runID
+
+	watchedNamespaces := []string{primaryWatchedNamespace, secondaryWatchedNamespace}
+	watchedNamespaces = append(watchedNamespaces, e2eHelmWatchedNamespaces...)
+	watchCSV := strings.Join(watchedNamespaces, ",")
+
+	r.registerScenario("namespace", release, operatorNamespace, operatorNamespace, unwatchedNamespace)
+	r.appendCurrentNamespaces(watchedNamespaces...)
+	r.enableFailureDiagnosticsAndCleanup()
+
+	r.testingT.Logf("Starting namespace-scope upgrade scenario with run-id %s", r.runID)
+	r.createNamespace(operatorNamespace)
+	for _, namespace := range watchedNamespaces {
+		r.createNamespace(namespace)
+	}
+	r.createNamespace(unwatchedNamespace)
+	r.adoptExistingCRDsForRelease(release, operatorNamespace)
+
+	r.runCommand("helm", "upgrade", "--install", release, r.sourceChart,
+		"--version", r.sourceVersion,
+		"--namespace", operatorNamespace,
+		"--create-namespace",
+		"--wait",
+		"--timeout", r.helmTimeout,
+	)
+
+	r.waitForOperatorReady(operatorNamespace)
+	r.deployMarkLogicCluster(primaryWatchedNamespace, "ml-upgrade-baseline")
+
+	r.runCommand("helm", r.buildTargetUpgradeArgs(release, operatorNamespace, "namespace", watchCSV)...)
+	r.waitForOperatorReady(operatorNamespace)
+
+	r.assertClusterResourceAbsent("clusterrole", "marklogic-operator-manager-role")
+	r.assertClusterResourceAbsent("clusterrolebinding", "marklogic-operator-manager-rolebinding")
+	r.assertClusterResourceAbsent("clusterrole", "marklogic-operator-metrics-auth-role")
+	r.assertClusterResourceAbsent("clusterrolebinding", "marklogic-operator-metrics-auth-rolebinding")
+	r.assertClusterResourceAbsent("clusterrole", "marklogic-operator-metrics-reader")
+
+	r.assertNamespacedResourcePresent("role", "marklogic-operator-manager-role", primaryWatchedNamespace)
+	r.assertNamespacedResourcePresent("rolebinding", "marklogic-operator-manager-rolebinding", primaryWatchedNamespace)
+	r.assertNamespacedResourcePresent("role", "marklogic-operator-manager-role", secondaryWatchedNamespace)
+	r.assertNamespacedResourcePresent("rolebinding", "marklogic-operator-manager-rolebinding", secondaryWatchedNamespace)
+	r.assertNamespacedResourcePresent("role", "marklogic-operator-manager-role", operatorNamespace)
+	r.assertNamespacedResourcePresent("rolebinding", "marklogic-operator-manager-rolebinding", operatorNamespace)
+
+	argsString := r.deploymentArgs(operatorNamespace)
+	envString := r.deploymentEnv(operatorNamespace)
+	r.assertContains(argsString, "--metrics-secure=false", "namespace-scope metrics must switch to insecure mode")
+	r.assertContains(argsString, "--metrics-bind-address=:8080", "namespace-scope metrics port must switch to 8080")
+	r.assertContains(envString, "WATCH_NAMESPACE="+watchCSV, "namespace-scope WATCH_NAMESPACE is incorrect")
+
+	r.waitForPodReady(primaryWatchedNamespace, "node-0")
+	r.deployMarkLogicCluster(secondaryWatchedNamespace, "ml-upgrade-post")
+	r.applyClusterManifest(unwatchedNamespace, "ml-upgrade-unwatched")
+	time.Sleep(cleanupProbeSleep)
+	if r.commandSucceeds("kubectl", "get", "statefulset", "node", "-n", unwatchedNamespace) {
+		r.testingT.Fatalf("unwatched namespace %s should not be reconciled, but statefulset/node was created", unwatchedNamespace)
+	}
+
+	r.appendCurrentNamespaces(e2eHelmCleanupNamespaces...)
+	r.runNamespaceE2ESuite(watchCSV)
+
+	r.testingT.Log("Namespace-scope upgrade scenario passed")
+}
+
+func (r *upgradeRunner) cleanupUpgradeTestResources() {
+	r.requireTools("kubectl", "helm")
+	r.testingT.Logf("Cleaning upgrade-test resources for run-id filter %q", r.runID)
+	found := false
+
+	for _, release := range r.findUpgradeTestReleases() {
+		found = true
+		r.testingT.Logf("Removing Helm release %s from namespace %s", release.name, release.namespace)
+		r.runCommandAllowFailure("helm", "uninstall", release.name, "--namespace", release.namespace, "--ignore-not-found")
+	}
+
+	r.cleanupClusterScopedRBAC()
+
+	for _, namespace := range r.findUpgradeTestNamespaces() {
+		found = true
+		r.testingT.Logf("Deleting namespace %s", namespace)
+		r.runCommandAllowFailure("kubectl", "delete", "namespace", namespace, "--ignore-not-found", "--wait=false")
+	}
+
+	if !found {
+		r.testingT.Log("No upgrade-test resources found")
+	}
+}
+
+func (r *upgradeRunner) ensureRunID() {
+	if strings.TrimSpace(r.runID) == "" {
+		r.runID = time.Now().Format("0102150405")
+	}
+}
+
+func (r *upgradeRunner) ensureHelmRepo() {
+	if r.skipHelmRepoUpdate || !strings.HasPrefix(r.sourceChart, "marklogic-operator/") {
+		return
+	}
+
+	r.runCommandAllowFailure("helm", "repo", "add", "marklogic-operator", "https://marklogic.github.io/marklogic-operator-kubernetes/")
+	r.runCommand("helm", "repo", "update", "marklogic-operator")
+}
+
+func (r *upgradeRunner) verifyClusterIsClean() {
+	deploymentNamespaces := strings.TrimSpace(r.runCommand("kubectl", "get", "deploy", "-A", "-o", `jsonpath={range .items[?(@.metadata.name=="marklogic-operator-controller-manager")]}{.metadata.namespace}{"\n"}{end}`))
+	if deploymentNamespaces != "" {
+		r.testingT.Fatalf("existing operator deployment found in namespace(s): %s", strings.ReplaceAll(deploymentNamespaces, "\n", ", "))
+	}
+
+	for _, name := range operatorClusterRoles {
+		if r.commandSucceeds("kubectl", "get", "clusterrole", name) {
+			r.testingT.Fatalf("existing ClusterRole %s found; use a clean cluster first", name)
+		}
+	}
+
+	for _, name := range operatorClusterRoleBindings {
+		if r.commandSucceeds("kubectl", "get", "clusterrolebinding", name) {
+			r.testingT.Fatalf("existing ClusterRoleBinding %s found; use a clean cluster first", name)
+		}
+	}
+
+	releases := strings.Fields(r.runCommand("helm", "list", "-A", "-q"))
+	var existing []string
+	for _, release := range releases {
+		if strings.Contains(release, "marklogic-operator") || strings.Contains(release, "mlop-upg") {
+			existing = append(existing, release)
+		}
+	}
+	if len(existing) > 0 {
+		r.testingT.Fatalf("existing Helm release(s) detected that look like operator installs: %s", strings.Join(existing, ", "))
+	}
+}
+
+func (r *upgradeRunner) verifyChartInputs() {
+	r.runCommand("kubectl", "cluster-info")
+	r.runCommand("helm", "show", "chart", r.sourceChart, "--version", r.sourceVersion)
+	r.runCommand("helm", "show", "chart", r.targetChart)
+}
+
+func (r *upgradeRunner) parseTargetImage() {
+	if r.targetImageRef == "" {
+		valuesOutput := r.runCommand("helm", "show", "values", r.targetChart)
+		var values chartValues
+		if err := yaml.Unmarshal([]byte(valuesOutput), &values); err != nil {
+			r.testingT.Fatalf("parse target chart values: %v", err)
+		}
+		repository := strings.TrimSpace(values.ControllerManager.Manager.Image.Repository)
+		tag := strings.TrimSpace(values.ControllerManager.Manager.Image.Tag)
+		if repository == "" || tag == "" {
+			r.testingT.Fatalf("unable to resolve controllerManager.manager.image.repository/tag from target chart values")
+		}
+		r.targetImageRepository = repository
+		r.targetImageTag = tag
+		r.targetImageRef = repository + ":" + tag
+		r.targetImageFromChart = true
+		return
+	}
+
+	separator := strings.LastIndex(r.targetImageRef, ":")
+	if separator <= strings.LastIndex(r.targetImageRef, "/") {
+		r.testingT.Fatalf("E2E_UPGRADE_TARGET_IMAGE must be repository:tag, got %q", r.targetImageRef)
+	}
+
+	r.targetImageRepository = r.targetImageRef[:separator]
+	r.targetImageTag = r.targetImageRef[separator+1:]
+	r.targetImageFromChart = false
+}
+
+func (r *upgradeRunner) verifyDefaultTargetImageAvailable() {
+	if !r.targetImageFromChart {
+		return
+	}
+
+	r.requireTools("docker")
+
+	if r.commandSucceeds("docker", "manifest", "inspect", r.targetImageRef) {
+		return
+	}
+
+	r.testingT.Fatalf("target chart default image %s is not available in a registry; build/load a local image and rerun with E2E_UPGRADE_TARGET_IMAGE or E2E_DOCKER_IMAGE set", r.targetImageRef)
+}
+
+func (r *upgradeRunner) registerScenario(name, release, operatorNamespace string, namespaces ...string) {
+	r.current = scenarioState{
+		name:              name,
+		release:           release,
+		operatorNamespace: operatorNamespace,
+		namespaces:        append([]string{}, namespaces...),
+	}
+}
+
+func (r *upgradeRunner) appendCurrentNamespaces(namespaces ...string) {
+	r.current.namespaces = append(r.current.namespaces, namespaces...)
+}
+
+func (r *upgradeRunner) enableFailureDiagnosticsAndCleanup() {
+	r.testingT.Cleanup(func() {
+		if r.testingT.Failed() && r.current.name != "" {
+			r.collectDiagnostics()
+		}
+		if !r.keepResources && r.current.name != "" {
+			r.cleanupCurrentScenario()
+		}
+	})
+}
+
+func (r *upgradeRunner) collectDiagnostics() {
+	r.testingT.Logf("Collecting diagnostics for scenario %s", r.current.name)
+	r.runCommandAllowFailure("kubectl", "get", "pods", "-A")
+	r.runCommandAllowFailure("kubectl", "get", "clusterrole,clusterrolebinding")
+
+	if r.current.operatorNamespace != "" {
+		r.runCommandAllowFailure("kubectl", "get", "deploy,pods,svc", "-n", r.current.operatorNamespace)
+		r.runCommandAllowFailure("kubectl", "logs", "deployment/"+defaultOperatorDeployment, "-n", r.current.operatorNamespace, "--tail=200")
+	}
+
+	for _, namespace := range r.current.namespaces {
+		r.runCommandAllowFailure("kubectl", "get", "all", "-n", namespace)
+		r.runCommandAllowFailure("kubectl", "get", "role,rolebinding", "-n", namespace)
+		r.runCommandAllowFailure("kubectl", "get", "marklogicclusters,marklogicgroups", "-n", namespace, "-o", "yaml")
+	}
+}
+
+func (r *upgradeRunner) cleanupCurrentScenario() {
+	if r.current.release != "" && r.current.operatorNamespace != "" {
+		r.testingT.Logf("Cleaning Helm release %s", r.current.release)
+		r.runCommandAllowFailure("helm", "uninstall", r.current.release, "--namespace", r.current.operatorNamespace, "--ignore-not-found")
+	}
+
+	r.cleanupClusterScopedRBAC()
+
+	for _, namespace := range r.current.namespaces {
+		r.runCommandAllowFailure("kubectl", "delete", "namespace", namespace, "--ignore-not-found", "--wait=false")
+	}
+
+	r.current = scenarioState{}
+}
+
+func (r *upgradeRunner) cleanupClusterScopedRBAC() {
+	for _, name := range operatorClusterRoleBindings {
+		r.runCommandAllowFailure("kubectl", "delete", "clusterrolebinding", name, "--ignore-not-found")
+	}
+	for _, name := range operatorClusterRoles {
+		r.runCommandAllowFailure("kubectl", "delete", "clusterrole", name, "--ignore-not-found")
+	}
+}
+
+func (r *upgradeRunner) adoptExistingCRDsForRelease(release, namespace string) {
+	for _, crd := range marklogicCRDs {
+		if !r.commandSucceeds("kubectl", "get", "crd", crd) {
+			continue
+		}
+
+		r.runCommand("kubectl", "label", "crd", crd, "app.kubernetes.io/managed-by=Helm", "--overwrite")
+		r.runCommand("kubectl", "annotate", "crd", crd,
+			"meta.helm.sh/release-name="+release,
+			"meta.helm.sh/release-namespace="+namespace,
+			"--overwrite",
+		)
+	}
+}
+
+func (r *upgradeRunner) waitForOperatorReady(namespace string) {
+	r.runCommand("kubectl", "rollout", "status", "deployment/"+defaultOperatorDeployment, "-n", namespace, "--timeout", r.helmTimeout)
+}
+
+func (r *upgradeRunner) waitForPodReady(namespace, podName string) {
+	deadline := time.Now().Add(r.workloadWaitTimeout)
+	for time.Now().Before(deadline) {
+		if r.commandSucceeds("kubectl", "get", "pod", podName, "-n", namespace) {
+			remaining := time.Until(deadline).Round(time.Second)
+			if remaining < time.Second {
+				remaining = time.Second
+			}
+			r.runCommand("kubectl", "wait", "--for=condition=Ready", "pod/"+podName, "-n", namespace, "--timeout", remaining.String())
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+
+	r.testingT.Fatalf("timed out waiting for pod %s in namespace %s", podName, namespace)
+}
+
+func (r *upgradeRunner) deployMarkLogicCluster(namespace, clusterName string) {
+	r.applyClusterManifest(namespace, clusterName)
+	r.waitForPodReady(namespace, "node-0")
+}
+
+func (r *upgradeRunner) applyClusterManifest(namespace, clusterName string) {
+	manifest, err := os.CreateTemp("", "marklogic-upgrade-*.yaml")
+	if err != nil {
+		r.testingT.Fatalf("create temp manifest: %v", err)
+	}
+	defer os.Remove(manifest.Name())
+
+	content := fmt.Sprintf(`apiVersion: marklogic.progress.com/v1
+kind: MarklogicCluster
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image: %s
+  persistence:
+    enabled: false
+    size: 10Gi
+  markLogicGroups:
+  - name: node
+    replicas: 1
+    isBootstrap: true
+`, clusterName, namespace, r.marklogicImage)
+
+	if _, err := manifest.WriteString(content); err != nil {
+		_ = manifest.Close()
+		r.testingT.Fatalf("write temp manifest: %v", err)
+	}
+	if err := manifest.Close(); err != nil {
+		r.testingT.Fatalf("close temp manifest: %v", err)
+	}
+
+	r.runCommand("kubectl", "apply", "-f", manifest.Name())
+}
+
+func (r *upgradeRunner) createNamespace(namespace string) {
+	r.runCommandAllowFailure("kubectl", "create", "namespace", namespace)
+}
+
+func (r *upgradeRunner) runClusterE2ESuite() {
+	env := map[string]string{
+		"E2E_USE_EXISTING_OPERATOR":   "true",
+		"E2E_OPERATOR_NAMESPACE":      r.current.operatorNamespace,
+		"E2E_MARKLOGIC_IMAGE_VERSION": r.marklogicImage,
+	}
+	if r.targetImageRef != "" {
+		env["E2E_DOCKER_IMAGE"] = r.targetImageRef
+	}
+
+	r.testingT.Log("Running cluster-scoped e2e suite against upgraded operator")
+	r.runStreamingCommand(env, "go", "test", "-count=1", "-timeout", r.clusterSuiteTimeout, "-v", "./test/e2e")
+}
+
+func (r *upgradeRunner) runNamespaceE2ESuite(watchedNamespacesCSV string) {
+	env := map[string]string{
+		"E2E_USE_EXISTING_OPERATOR":   "true",
+		"E2E_OPERATOR_NAMESPACE":      r.current.operatorNamespace,
+		"E2E_OPERATOR_RELEASE":        r.current.release,
+		"E2E_WATCHED_NAMESPACES":      watchedNamespacesCSV,
+		"E2E_MARKLOGIC_IMAGE_VERSION": r.marklogicImage,
+	}
+	if r.targetImageRef != "" {
+		env["E2E_DOCKER_IMAGE"] = r.targetImageRef
+	}
+
+	r.testingT.Log("Running namespace-scoped e2e suite against upgraded operator")
+	r.runStreamingCommand(env, "go", "test", "-count=1", "-timeout", r.namespaceSuiteTimeout, "-v", "./test/e2e-helm")
+}
+
+func (r *upgradeRunner) buildTargetUpgradeArgs(release, operatorNamespace, scope, watchedNamespaces string) []string {
+	args := []string{
+		"upgrade",
+		release,
+		r.targetChart,
+		"--namespace", operatorNamespace,
+		"--wait",
+		"--timeout", r.helmTimeout,
+		"--set", "scope.type=" + scope,
+	}
+
+	if watchedNamespaces != "" {
+		args = append(args, "--set-string", "scope.watchNamespaces="+watchedNamespaces)
+	}
+
+	if scope == "namespace" {
+		args = append(args, "--set", "metrics.secure=false")
+	} else {
+		args = append(args, "--set", "metrics.secure=true")
+	}
+
+	if r.targetImageRepository != "" {
+		args = append(args,
+			"--set", "controllerManager.manager.image.repository="+r.targetImageRepository,
+			"--set", "controllerManager.manager.image.tag="+r.targetImageTag,
+		)
+	}
+
+	return args
+}
+
+func (r *upgradeRunner) assertClusterResourcePresent(kind, name string) {
+	if !r.commandSucceeds("kubectl", "get", kind, name) {
+		r.testingT.Fatalf("expected %s/%s to exist", kind, name)
+	}
+}
+
+func (r *upgradeRunner) assertClusterResourceAbsent(kind, name string) {
+	if r.commandSucceeds("kubectl", "get", kind, name) {
+		r.testingT.Fatalf("expected %s/%s to be absent", kind, name)
+	}
+}
+
+func (r *upgradeRunner) assertNamespacedResourcePresent(kind, name, namespace string) {
+	if !r.commandSucceeds("kubectl", "get", kind, name, "-n", namespace) {
+		r.testingT.Fatalf("expected %s/%s in namespace %s", kind, name, namespace)
+	}
+}
+
+func (r *upgradeRunner) deploymentArgs(namespace string) string {
+	return strings.TrimSpace(r.runCommand("kubectl", "get", "deployment", defaultOperatorDeployment, "-n", namespace, "-o", `jsonpath={.spec.template.spec.containers[0].args[*]}`))
+}
+
+func (r *upgradeRunner) deploymentEnv(namespace string) string {
+	return strings.TrimSpace(r.runCommand("kubectl", "get", "deployment", defaultOperatorDeployment, "-n", namespace, "-o", `jsonpath={range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}`))
+}
+
+func (r *upgradeRunner) assertContains(value, expected, description string) {
+	if !strings.Contains(value, expected) {
+		r.testingT.Fatalf("%s. expected to find %q in %q", description, expected, value)
+	}
+}
+
+func (r *upgradeRunner) assertNotContains(value, unexpected, description string) {
+	if strings.Contains(value, unexpected) {
+		r.testingT.Fatalf("%s. did not expect to find %q in %q", description, unexpected, value)
+	}
+}
+
+func (r *upgradeRunner) findUpgradeTestReleases() []releaseRef {
+	output := strings.TrimSpace(r.runCommandAllowFailure("helm", "list", "-A", "--no-headers"))
+	if output == "" {
+		return nil
+	}
+
+	var releases []releaseRef
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name, namespace := fields[0], fields[1]
+		if matchesUpgradeReleaseName(name, r.runID) {
+			releases = append(releases, releaseRef{name: name, namespace: namespace})
+		}
+	}
+
+	return releases
+}
+
+func (r *upgradeRunner) findUpgradeTestNamespaces() []string {
+	output := strings.TrimSpace(r.runCommandAllowFailure("kubectl", "get", "ns", "-o", `jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}`))
+	if output == "" {
+		return nil
+	}
+
+	var namespaces []string
+	for _, namespace := range strings.Split(output, "\n") {
+		if matchesUpgradeNamespace(namespace, r.runID) {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+
+	return namespaces
+}
+
+type releaseRef struct {
+	name      string
+	namespace string
+}
+
+func matchesUpgradeReleaseName(name, runID string) bool {
+	if !(strings.HasPrefix(name, "mlop-upg-cluster-") || strings.HasPrefix(name, "mlop-upg-ns-")) {
+		return false
+	}
+	return runID == "" || strings.HasSuffix(name, "-"+runID)
+}
+
+func matchesUpgradeNamespace(namespace, runID string) bool {
+	prefixes := []string{
+		"mlop-upg-cluster-",
+		"mlop-upg-ns-",
+		"ml-upg-base-",
+		"ml-upg-post-",
+		"ml-upg-watch-a-",
+		"ml-upg-watch-b-",
+		"ml-upg-unwatched-",
+	}
+	matched := false
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(namespace, prefix) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+	return runID == "" || strings.HasSuffix(namespace, "-"+runID)
+}
+
+func (r *upgradeRunner) requireTools(names ...string) {
+	for _, name := range names {
+		if _, err := exec.LookPath(name); err != nil {
+			r.testingT.Fatalf("required tool not found: %s", name)
+		}
+	}
+}
+
+func (r *upgradeRunner) commandSucceeds(name string, args ...string) bool {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = r.repoRoot
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		r.testingT.Logf("command failed (ignored): %s %s\n%s", name, strings.Join(args, " "), strings.TrimSpace(string(out)))
+		return false
+	}
+	return true
+}
+
+func (r *upgradeRunner) runCommand(name string, args ...string) string {
+	r.testingT.Helper()
+	out, err := r.execute(nil, false, name, args...)
+	if err != nil {
+		r.testingT.Fatalf("command failed: %s %s\n%s", name, strings.Join(args, " "), strings.TrimSpace(out))
+	}
+	return out
+}
+
+func (r *upgradeRunner) runCommandAllowFailure(name string, args ...string) string {
+	r.testingT.Helper()
+	out, err := r.execute(nil, false, name, args...)
+	if err != nil {
+		r.testingT.Logf("command failed (ignored): %s %s\n%s", name, strings.Join(args, " "), strings.TrimSpace(out))
+	}
+	return out
+}
+
+func (r *upgradeRunner) runStreamingCommand(extraEnv map[string]string, name string, args ...string) {
+	r.testingT.Helper()
+	out, err := r.execute(extraEnv, true, name, args...)
+	if err != nil {
+		r.testingT.Fatalf("command failed: %s %s\n%s", name, strings.Join(args, " "), strings.TrimSpace(out))
+	}
+}
+
+func (r *upgradeRunner) execute(extraEnv map[string]string, stream bool, name string, args ...string) (string, error) {
+	r.testingT.Helper()
+	r.testingT.Logf("running: %s %s", name, strings.Join(args, " "))
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = r.repoRoot
+	cmd.Env = mergeEnv(os.Environ(), extraEnv)
+
+	if !stream {
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	var buffer bytes.Buffer
+	multiWriter := io.MultiWriter(os.Stdout, &buffer)
+	cmd.Stdout = multiWriter
+	cmd.Stderr = multiWriter
+	err := cmd.Run()
+	return buffer.String(), err
+}
+
+func findRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		candidate := filepath.Join(wd, "go.mod")
+		if _, err := os.Stat(candidate); err == nil {
+			return wd, nil
+		}
+
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			return "", fmt.Errorf("could not find go.mod above %s", wd)
+		}
+		wd = parent
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func boolEnv(key string) bool {
+	value := strings.TrimSpace(os.Getenv(key))
+	return strings.EqualFold(value, "true") || value == "1" || strings.EqualFold(value, "yes")
+}
+
+func durationEnvOrDefault(key string, fallback time.Duration) time.Duration {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func mergeEnv(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+
+	result := append([]string{}, base...)
+	for key, value := range overrides {
+		prefix := key + "="
+		replaced := false
+		for i, entry := range result {
+			if strings.HasPrefix(entry, prefix) {
+				result[i] = prefix + value
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			result = append(result, prefix+value)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary
This PR adds automated operator upgrade coverage for 1.3.0 and future releases.

It introduces a dedicated upgrade e2e suite that installs the previous released Helm chart, upgrades it to the current build, and validates both cluster-scoped and namespace-scoped operator behavior after the upgrade. The new flow verifies that RBAC, metrics configuration, watched namespace handling, and workload reconciliation remain correct, then reruns the existing e2e suites against the upgraded operator.

## Changes
- Add a new upgradee2e test suite for cluster-scoped and namespace-scoped upgrade scenarios
- Validate upgrade behavior from Helm chart 1.2.0 to the current operator image/chart
- Confirm post-upgrade RBAC and metrics settings for both scope modes
- Verify watched namespaces continue to reconcile and unwatched namespaces do not
- Allow the existing e2e suites to run against an already-installed upgraded operator
- Add Make targets for upgrade test execution and cleanup
- Wire the new upgrade flows into Jenkins
- Add the dynamic-host sample manifest for e2e coverage