### PR TITLE
MLE-31592: support secret-backed fluent bit ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ kubectl get secret single-node-admin --namespace=<namespace-name> -o jsonpath='{
 
 For additional manifests to deploy a MarkLogic cluster inside a Kubernetes cluster, see [Operator manifest](https://docs.progress.com/bundle/marklogic-server-on-kubernetes/operator/Operator-manifest.html) in the documentation.
 
+For Fluent Bit log collection configuration, including secret-backed environment variables for authenticated OpenTelemetry exports, see [Fluent Bit Log Collection](./docs/log-collection.md).
+
 ## Clean Up
 
 #### Cleaning up MarkLogic Cluster

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -85,6 +85,7 @@ type LogCollection struct {
 	SecurityContext  *corev1.SecurityContext       `json:"securityContext,omitempty"`
 	// +kubebuilder:default:={"requests":{"cpu":"100m","memory":"200Mi"},"limits":{"cpu":"200m","memory":"500Mi"}}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	Env       []corev1.EnvVar              `json:"env,omitempty"`
 	// +kubebuilder:default:={errorLogs: true, accessLogs: true, requestLogs: true, crashLogs: true, auditLogs: true}
 	Files   LogFilesConfig `json:"files,omitempty"`
 	Outputs string         `json:"outputs,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -374,6 +374,13 @@ func (in *LogCollection) DeepCopyInto(out *LogCollection) {
 		*out = new(corev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]corev1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.Files = in.Files
 }
 

--- a/charts/marklogic-operator-kubernetes/templates/marklogiccluster-crd.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/marklogiccluster-crd.yaml
@@ -5146,6 +5146,162 @@ spec:
                   enabled:
                     default: false
                     type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+  
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   files:
                     default:
                       accessLogs: true
@@ -8935,6 +9091,163 @@ spec:
                         enabled:
                           default: false
                           type: boolean
+                        env:
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+  
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing
+                                          the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         files:
                           default:
                             accessLogs: true

--- a/charts/marklogic-operator-kubernetes/templates/marklogicgroup-crd.yaml
+++ b/charts/marklogic-operator-kubernetes/templates/marklogicgroup-crd.yaml
@@ -3487,6 +3487,162 @@ spec:
                   enabled:
                     default: false
                     type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+  
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   files:
                     default:
                       accessLogs: true

--- a/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
+++ b/config/crd/bases/marklogic.progress.com_marklogicclusters.yaml
@@ -5157,6 +5157,163 @@ spec:
                   enabled:
                     default: false
                     type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   files:
                     default:
                       accessLogs: true
@@ -8961,6 +9118,163 @@ spec:
                         enabled:
                           default: false
                           type: boolean
+                        env:
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         files:
                           default:
                             accessLogs: true

--- a/config/crd/bases/marklogic.progress.com_marklogicgroups.yaml
+++ b/config/crd/bases/marklogic.progress.com_marklogicgroups.yaml
@@ -3494,6 +3494,163 @@ spec:
                   enabled:
                     default: false
                     type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   files:
                     default:
                       accessLogs: true

--- a/docs/log-collection.md
+++ b/docs/log-collection.md
@@ -1,0 +1,46 @@
+# Fluent Bit Log Collection
+
+## Secret-Backed Environment Variables
+
+The Fluent Bit sidecar can consume Kubernetes environment variables configured in `spec.logCollection.env`. This uses the standard Kubernetes `EnvVar` schema, including `valueFrom.secretKeyRef`, so secret values are not written to the Fluent Bit ConfigMap.
+
+Create the secret in the same namespace as the MarkLogic resource:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: otel-auth
+stringData:
+  token: replace-with-your-token
+```
+
+Reference one key from that secret in the log collection configuration:
+
+```yaml
+apiVersion: marklogic.progress.com/v1
+kind: MarklogicCluster
+metadata:
+  name: example
+spec:
+  logCollection:
+    enabled: true
+    env:
+      - name: OTEL_AUTH_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: otel-auth
+            key: token
+    outputs: |
+      - name: opentelemetry
+        match: kube.marklogic.logs.*
+        host: otel-collector.observability
+        port: 4317
+        grpc: 'on'
+        header:
+          - Authorization Bearer ${OTEL_AUTH_TOKEN}
+```
+
+The same `logCollection.env` field is available on an individual `MarklogicGroup`. A group-level `logCollection` overrides the cluster-level log collection configuration for that group.
+
+`POD_NAME` and `NAMESPACE` remain available automatically in the Fluent Bit container. The operator copies configured environment-variable references to the Fluent Bit container without resolving secret values. Kubernetes resolves the reference when it starts the pod.

--- a/pkg/k8sutil/security_context_test.go
+++ b/pkg/k8sutil/security_context_test.go
@@ -41,6 +41,58 @@ func TestGenerateContainerDefAppliesFluentBitSecurityContext(t *testing.T) {
 	}
 }
 
+func TestGenerateContainerDefAppliesFluentBitEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	containerDefs := generateContainerDef("marklogic-server", containerParameters{
+		LogCollection: &marklogicv1.LogCollection{
+			Enabled: true,
+			Image:   "fluent/fluent-bit:4.1.1",
+			Env: []corev1.EnvVar{
+				{
+					Name: "OTEL_AUTH_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "otel-auth"},
+							Key:                  "token",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if len(containerDefs) != 2 {
+		t.Fatalf("expected marklogic and fluent-bit containers, got %d", len(containerDefs))
+	}
+
+	fluentBitContainer := containerDefs[1]
+	if len(fluentBitContainer.Env) != 3 {
+		t.Fatalf("expected Fluent Bit environment variables plus the configured token, got %d", len(fluentBitContainer.Env))
+	}
+
+	podName := fluentBitContainer.Env[0]
+	if podName.Name != "POD_NAME" || podName.ValueFrom == nil || podName.ValueFrom.FieldRef == nil || podName.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+		t.Fatalf("expected POD_NAME from metadata.name, got %+v", podName)
+	}
+
+	namespace := fluentBitContainer.Env[1]
+	if namespace.Name != "NAMESPACE" || namespace.ValueFrom == nil || namespace.ValueFrom.FieldRef == nil || namespace.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+		t.Fatalf("expected NAMESPACE from metadata.namespace, got %+v", namespace)
+	}
+
+	token := fluentBitContainer.Env[2]
+	if token.Name != "OTEL_AUTH_TOKEN" {
+		t.Fatalf("expected OTEL_AUTH_TOKEN environment variable, got %s", token.Name)
+	}
+	if token.ValueFrom == nil || token.ValueFrom.SecretKeyRef == nil {
+		t.Fatal("expected OTEL_AUTH_TOKEN to retain its secret reference")
+	}
+	if token.ValueFrom.SecretKeyRef.Name != "otel-auth" || token.ValueFrom.SecretKeyRef.Key != "token" {
+		t.Fatalf("expected OTEL_AUTH_TOKEN to use otel-auth/token, got %+v", token.ValueFrom.SecretKeyRef)
+	}
+}
+
 func TestCreateHAProxyDeploymentDefAppliesSecurityContexts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/k8sutil/security_context_test.go
+++ b/pkg/k8sutil/security_context_test.go
@@ -92,6 +92,7 @@ func TestGenerateContainerDefAppliesFluentBitEnvironmentVariables(t *testing.T) 
 	if token.ValueFrom.SecretKeyRef.Name != "otel-auth" || token.ValueFrom.SecretKeyRef.Key != "token" {
 		t.Fatalf("expected OTEL_AUTH_TOKEN to use otel-auth/token, got %+v", token.ValueFrom.SecretKeyRef)
 	}
+}
 
 func TestCreateHAProxyDeploymentDefAppliesSecurityContexts(t *testing.T) {
 	t.Parallel()

--- a/pkg/k8sutil/security_context_test.go
+++ b/pkg/k8sutil/security_context_test.go
@@ -67,23 +67,24 @@ func TestGenerateContainerDefAppliesFluentBitEnvironmentVariables(t *testing.T) 
 	}
 
 	fluentBitContainer := containerDefs[1]
-	if len(fluentBitContainer.Env) != 3 {
-		t.Fatalf("expected Fluent Bit environment variables plus the configured token, got %d", len(fluentBitContainer.Env))
+	envByName := map[string]corev1.EnvVar{}
+	for _, envVar := range fluentBitContainer.Env {
+		envByName[envVar.Name] = envVar
 	}
 
-	podName := fluentBitContainer.Env[0]
-	if podName.Name != "POD_NAME" || podName.ValueFrom == nil || podName.ValueFrom.FieldRef == nil || podName.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+	podName, ok := envByName["POD_NAME"]
+	if !ok || podName.ValueFrom == nil || podName.ValueFrom.FieldRef == nil || podName.ValueFrom.FieldRef.FieldPath != "metadata.name" {
 		t.Fatalf("expected POD_NAME from metadata.name, got %+v", podName)
 	}
 
-	namespace := fluentBitContainer.Env[1]
-	if namespace.Name != "NAMESPACE" || namespace.ValueFrom == nil || namespace.ValueFrom.FieldRef == nil || namespace.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
+	namespace, ok := envByName["NAMESPACE"]
+	if !ok || namespace.ValueFrom == nil || namespace.ValueFrom.FieldRef == nil || namespace.ValueFrom.FieldRef.FieldPath != "metadata.namespace" {
 		t.Fatalf("expected NAMESPACE from metadata.namespace, got %+v", namespace)
 	}
 
-	token := fluentBitContainer.Env[2]
-	if token.Name != "OTEL_AUTH_TOKEN" {
-		t.Fatalf("expected OTEL_AUTH_TOKEN environment variable, got %s", token.Name)
+	token, ok := envByName["OTEL_AUTH_TOKEN"]
+	if !ok {
+		t.Fatal("expected OTEL_AUTH_TOKEN environment variable")
 	}
 	if token.ValueFrom == nil || token.ValueFrom.SecretKeyRef == nil {
 		t.Fatal("expected OTEL_AUTH_TOKEN to retain its secret reference")
@@ -91,7 +92,6 @@ func TestGenerateContainerDefAppliesFluentBitEnvironmentVariables(t *testing.T) 
 	if token.ValueFrom.SecretKeyRef.Name != "otel-auth" || token.ValueFrom.SecretKeyRef.Key != "token" {
 		t.Fatalf("expected OTEL_AUTH_TOKEN to use otel-auth/token, got %+v", token.ValueFrom.SecretKeyRef)
 	}
-}
 
 func TestCreateHAProxyDeploymentDefAppliesSecurityContexts(t *testing.T) {
 	t.Parallel()

--- a/pkg/k8sutil/statefulset.go
+++ b/pkg/k8sutil/statefulset.go
@@ -389,6 +389,7 @@ func generateContainerDef(name string, containerParams containerParameters) []co
 			SecurityContext: getFluentBitSecurityContextOrDefault(containerParams.LogCollection.SecurityContext),
 			VolumeMounts:    getFluentBitVolumeMount(containerParams),
 		}
+		fulentBitContainerDef.Env = append(fulentBitContainerDef.Env, containerParams.LogCollection.Env...)
 		if containerParams.LogCollection.Resources != nil {
 			fulentBitContainerDef.Resources = *containerParams.LogCollection.Resources
 		}

--- a/pkg/k8sutil/statefulset.go
+++ b/pkg/k8sutil/statefulset.go
@@ -379,7 +379,7 @@ func generateContainerDef(name string, containerParams containerParameters) []co
 	}
 
 	if containerParams.LogCollection != nil && containerParams.LogCollection.Enabled {
-		fulentBitContainerDef := corev1.Container{
+		fluentBitContainerDef := corev1.Container{
 			Name:            "fluent-bit",
 			Image:           containerParams.LogCollection.Image,
 			ImagePullPolicy: "IfNotPresent",
@@ -394,12 +394,12 @@ func generateContainerDef(name string, containerParams containerParameters) []co
 			if envVar.Name == "POD_NAME" || envVar.Name == "NAMESPACE" {
 				continue
 			}
-			fulentBitContainerDef.Env = append(fulentBitContainerDef.Env, envVar)
+			fluentBitContainerDef.Env = append(fluentBitContainerDef.Env, envVar)
 		}
 		if containerParams.LogCollection.Resources != nil {
-			fulentBitContainerDef.Resources = *containerParams.LogCollection.Resources
+			fluentBitContainerDef.Resources = *containerParams.LogCollection.Resources
 		}
-		containerDef = append(containerDef, fulentBitContainerDef)
+		containerDef = append(containerDef, fluentBitContainerDef)
 	}
 
 	return containerDef

--- a/pkg/k8sutil/statefulset.go
+++ b/pkg/k8sutil/statefulset.go
@@ -389,7 +389,13 @@ func generateContainerDef(name string, containerParams containerParameters) []co
 			SecurityContext: getFluentBitSecurityContextOrDefault(containerParams.LogCollection.SecurityContext),
 			VolumeMounts:    getFluentBitVolumeMount(containerParams),
 		}
-		fulentBitContainerDef.Env = append(fulentBitContainerDef.Env, containerParams.LogCollection.Env...)
+		// Prevent user configuration from overriding operator-provided env vars.
+		for _, envVar := range containerParams.LogCollection.Env {
+			if envVar.Name == "POD_NAME" || envVar.Name == "NAMESPACE" {
+				continue
+			}
+			fulentBitContainerDef.Env = append(fulentBitContainerDef.Env, envVar)
+		}
 		if containerParams.LogCollection.Resources != nil {
 			fulentBitContainerDef.Resources = *containerParams.LogCollection.Resources
 		}

--- a/test/e2e/6_log_collection_test.go
+++ b/test/e2e/6_log_collection_test.go
@@ -428,15 +428,7 @@ func TestLogCollectionSecretBackedEnvironment(t *testing.T) {
 			t.Fatalf("Failed to create MarklogicCluster: %s", err)
 		}
 
-		if err := wait.For(
-			conditions.New(client.Resources()).ResourceMatch(mlclusterSecretEnv, func(object k8s.Object) bool {
-				return true
-			}),
-			wait.WithTimeout(3*time.Minute),
-			wait.WithInterval(5*time.Second),
-		); err != nil {
-			t.Fatal(err)
-		}
+		// Create() already persists the resource in the API server; pod startup is validated in the assessment phase.
 		return ctx
 	})
 

--- a/test/e2e/6_log_collection_test.go
+++ b/test/e2e/6_log_collection_test.go
@@ -338,6 +338,163 @@ func TestLogCollectionPartialLogs(t *testing.T) {
 	testEnv.Test(t, feature.Feature())
 }
 
+func TestLogCollectionSecretBackedEnvironment(t *testing.T) {
+	trackTest(t)
+	feature := features.New("Log Collection Secret-Backed Environment Test").WithLabel("type", "log-collection-secret-env")
+
+	replicas := int32(1)
+	adminUser := "admin"
+	adminPass := "Admin@8001"
+
+	mlclusterSecretEnv := &marklogicv1.MarklogicCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "marklogic.progress.com/v1",
+			Kind:       "MarklogicCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ml-secret-env",
+			Namespace: logCollectionNamespace,
+		},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: marklogicImage,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &adminUser,
+				AdminPassword: &adminPass,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{
+				{
+					Name:        logGroupName,
+					Replicas:    &replicas,
+					IsBootstrap: true,
+				},
+			},
+			LogCollection: &marklogicv1.LogCollection{
+				Enabled: true,
+				Image:   "fluent/fluent-bit:4.1.1",
+				Env: []corev1.EnvVar{
+					{
+						Name: "OTEL_AUTH_TOKEN",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "otel-auth"},
+								Key:                  "token",
+							},
+						},
+					},
+				},
+				Files:   marklogicv1.LogFilesConfig{ErrorLogs: true},
+				Outputs: "[OUTPUT]\n\tname stdout\n\tmatch *",
+			},
+		},
+	}
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logCollectionNamespace}}
+		if err := client.Resources().Get(ctx, logCollectionNamespace, "", ns); err == nil {
+			if err := client.Resources().Delete(ctx, ns); err != nil {
+				t.Logf("Failed to delete existing namespace: %v", err)
+			}
+			if err := wait.For(
+				conditions.New(client.Resources()).ResourceDeleted(ns),
+				wait.WithTimeout(2*time.Minute),
+				wait.WithInterval(2*time.Second),
+			); err != nil {
+				t.Logf("Warning: namespace deletion timeout, proceeding anyway: %v", err)
+			}
+		}
+
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   logCollectionNamespace,
+				Labels: namespaceLabels(),
+			},
+		}
+		if err := client.Resources().Create(ctx, namespace); err != nil {
+			t.Fatalf("Failed to create namespace: %s", err)
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "otel-auth", Namespace: logCollectionNamespace},
+			StringData: map[string]string{"token": "test-token"},
+		}
+		if err := client.Resources(logCollectionNamespace).Create(ctx, secret); err != nil {
+			t.Fatalf("Failed to create OpenTelemetry authentication secret: %s", err)
+		}
+
+		marklogicv1.AddToScheme(client.Resources(logCollectionNamespace).GetScheme())
+		if err := client.Resources(logCollectionNamespace).Create(ctx, mlclusterSecretEnv); err != nil {
+			t.Fatalf("Failed to create MarklogicCluster: %s", err)
+		}
+
+		if err := wait.For(
+			conditions.New(client.Resources()).ResourceMatch(mlclusterSecretEnv, func(object k8s.Object) bool {
+				return true
+			}),
+			wait.WithTimeout(3*time.Minute),
+			wait.WithInterval(5*time.Second),
+		); err != nil {
+			t.Fatal(err)
+		}
+		return ctx
+	})
+
+	feature.Assess("Fluent-bit references the OpenTelemetry authentication secret", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		podName := "lognode-0"
+		if err := utils.WaitForPod(ctx, t, client, logCollectionNamespace, podName, 120*time.Second); err != nil {
+			t.Fatalf("Failed to wait for pod creation: %v", err)
+		}
+
+		var pod corev1.Pod
+		if err := client.Resources().Get(ctx, podName, logCollectionNamespace, &pod); err != nil {
+			t.Fatalf("Failed to get pod: %v", err)
+		}
+
+		var fluentBitContainer *corev1.Container
+		for index := range pod.Spec.Containers {
+			if pod.Spec.Containers[index].Name == "fluent-bit" {
+				fluentBitContainer = &pod.Spec.Containers[index]
+				break
+			}
+		}
+		if fluentBitContainer == nil {
+			t.Fatal("Fluent-bit container not found")
+		}
+
+		for _, envVar := range fluentBitContainer.Env {
+			if envVar.Name != "OTEL_AUTH_TOKEN" {
+				continue
+			}
+			if envVar.ValueFrom == nil || envVar.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("OTEL_AUTH_TOKEN is not sourced from a Secret")
+			}
+			if envVar.ValueFrom.SecretKeyRef.Name != "otel-auth" || envVar.ValueFrom.SecretKeyRef.Key != "token" {
+				t.Fatalf("Expected OTEL_AUTH_TOKEN to reference otel-auth/token, got %+v", envVar.ValueFrom.SecretKeyRef)
+			}
+			t.Log("Verified Fluent-bit references the OpenTelemetry authentication secret")
+			return ctx
+		}
+
+		t.Fatal("OTEL_AUTH_TOKEN environment variable not found on Fluent-bit")
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client := c.Client()
+		if err := client.Resources(logCollectionNamespace).Delete(ctx, mlclusterSecretEnv); err != nil {
+			t.Fatalf("Failed to delete MarklogicCluster: %s", err)
+		}
+		if err := client.Resources().Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logCollectionNamespace}}); err != nil {
+			t.Fatalf("Failed to delete namespace: %s", err)
+		}
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
 // TestLogCollectionCustomResources tests custom resource configuration for fluent-bit
 func TestLogCollectionCustomResources(t *testing.T) {
 	trackTest(t)


### PR DESCRIPTION
Adds support for configuring environment variables on the Fluent Bit sidecar through spec.logCollection.env.

This enables Secret-backed OpenTelemetry authentication without exposing tokens in the Fluent Bit ConfigMap. Users can reference a Secret key through a standard Kubernetes EnvVar, then use the environment variable in a Fluent Bit output header such as:

header:
  - Authorization Bearer ${OTEL_AUTH_TOKEN}