### PR TITLE
MLE-29912 OAuth 2.0 Authorization Code Flow: Load Balancer Session Affinity Testing

### DIFF
--- a/internal/controller/marklogicgroup_controller_test.go
+++ b/internal/controller/marklogicgroup_controller_test.go
@@ -2802,6 +2802,18 @@ func (f *fakeDynamicManagementClient) RemoveDynamicHost(ctx context.Context, clu
 	return nil
 }
 
+func (f *fakeDynamicManagementClient) ImportCertificateAuthority(ctx context.Context, authorityPEM string) error {
+	return nil
+}
+
+func (f *fakeDynamicManagementClient) EnsureOAuthExternalSecurity(ctx context.Context, config mlmanage.OAuthExternalSecurityConfig) error {
+	return nil
+}
+
+func (f *fakeDynamicManagementClient) EnsureOAuthAppServer(ctx context.Context, config mlmanage.OAuthAppServerConfig) error {
+	return nil
+}
+
 func upsertFakeGroupHost(hosts []mlmanage.GroupHost, candidate mlmanage.GroupHost) []mlmanage.GroupHost {
 	for i := range hosts {
 		if hosts[i].Name == candidate.Name {

--- a/pkg/k8sutil/dynamic_reconcile_test.go
+++ b/pkg/k8sutil/dynamic_reconcile_test.go
@@ -145,6 +145,18 @@ func (s *stubDynamicManagementClient) RemoveDynamicHost(ctx context.Context, clu
 	return nil
 }
 
+func (s *stubDynamicManagementClient) ImportCertificateAuthority(ctx context.Context, authorityPEM string) error {
+	return nil
+}
+
+func (s *stubDynamicManagementClient) EnsureOAuthExternalSecurity(ctx context.Context, config mlmanage.OAuthExternalSecurityConfig) error {
+	return nil
+}
+
+func (s *stubDynamicManagementClient) EnsureOAuthAppServer(ctx context.Context, config mlmanage.OAuthAppServerConfig) error {
+	return nil
+}
+
 func TestJoinDynamicPodSuccess(t *testing.T) {
 	oc := &OperatorContext{Ctx: context.Background()}
 

--- a/pkg/k8sutil/haProxy.go
+++ b/pkg/k8sutil/haProxy.go
@@ -296,6 +296,14 @@ func (cc *ClusterContext) createHAProxyDeploymentDef(meta metav1.ObjectMeta) *ap
 				},
 			},
 		})
+		deploymentDef.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			deploymentDef.Spec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "ssl-certificate",
+				MountPath: "/usr/local/etc/ssl",
+				ReadOnly:  true,
+			},
+		)
 	}
 	AddOwnerRefToObject(deploymentDef, ownerDef)
 	return deploymentDef

--- a/pkg/k8sutil/scripts/cluster-config.sh
+++ b/pkg/k8sutil/scripts/cluster-config.sh
@@ -247,13 +247,20 @@ function init_marklogic {
 # return values: 0 - admin user successfully initialized
 ################################################################
 function wait_bootstrap_ready {
-    resp=$(curl -w '%{http_code}' -o /dev/null http://$MARKLOGIC_BOOTSTRAP_HOST:8001/admin/v1/timestamp )
+    local body
+    body=$(mktemp)
+    resp=$(curl -s -w '%{http_code}' -o "$body" http://$MARKLOGIC_BOOTSTRAP_HOST:8001/admin/v1/timestamp )
     if [[ "$MARKLOGIC_JOIN_TLS_ENABLED" == "true" ]]; then
-        # return 403 if tls is enabled
-        if [[ $resp -eq 403 ]]; then
+        # The bootstrap host is ready once its Admin endpoint stops serving the
+        # timestamp openly. MarkLogic 12.0.x rejects the plaintext request with
+        # 403 (HTTPS required), while 12.1+ responds 500 with XDMP-NOUSER
+        # (authentication required). Accept either as the TLS-enabled ready signal.
+        if [[ $resp -eq 403 ]] || { [[ $resp -eq 500 ]] && grep -q "XDMP-NOUSER" "$body"; }; then
             info "Bootstrap host is ready with TLS enabled"
+            rm -f "$body"
         else
             info "Calling Bootstrap host with response code:$resp. Bootstrap host is not ready with TLS enabled, try again in 10s"
+            rm -f "$body"
             sleep 10s
             wait_bootstrap_ready
             return 0
@@ -261,8 +268,10 @@ function wait_bootstrap_ready {
     else
         if [[ $resp -eq 401 ]]; then
             info "Bootstrap host is ready with no TLS"
+            rm -f "$body"
         else
             info "Calling Bootstrap host with response code:$resp. Bootstrap host is not ready, try again in 10s"
+            rm -f "$body"
             sleep 10s
             wait_bootstrap_ready
             return 0

--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -495,14 +495,14 @@ func (c *managementClient) ImportCertificateAuthority(ctx context.Context, autho
 }
 
 func (c *managementClient) EnsureOAuthExternalSecurity(ctx context.Context, config OAuthExternalSecurityConfig) error {
-	query := url.Values{}
-	query.Set("format", "json")
-	_, statusCode, err := c.doJSON(ctx, http.MethodGet, "/manage/v2/external-security/"+url.PathEscape(config.Name), query, nil, http.StatusOK, http.StatusNotFound)
+	payload, err := BuildOAuthExternalSecurityPayload(config)
 	if err != nil {
 		return err
 	}
 
-	payload, err := BuildOAuthExternalSecurityPayload(config)
+	query := url.Values{}
+	query.Set("format", "json")
+	_, statusCode, err := c.doJSON(ctx, http.MethodGet, "/manage/v2/external-security/"+url.PathEscape(config.Name), query, nil, http.StatusOK, http.StatusNotFound)
 	if err != nil {
 		return err
 	}

--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -36,6 +36,9 @@ type Client interface {
 	JoinDynamicHost(ctx context.Context, hostFQDN, token string) error
 	ListGroupHosts(ctx context.Context, groupName string) ([]GroupHost, error)
 	RemoveDynamicHost(ctx context.Context, clusterName, hostID string) error
+	ImportCertificateAuthority(ctx context.Context, authorityPEM string) error
+	EnsureOAuthExternalSecurity(ctx context.Context, config OAuthExternalSecurityConfig) error
+	EnsureOAuthAppServer(ctx context.Context, config OAuthAppServerConfig) error
 }
 
 type ClientOptions struct {
@@ -62,6 +65,36 @@ type GroupHost struct {
 	Name   string
 	HostID string
 	Online bool
+}
+
+type OAuthExternalSecurityConfig struct {
+	Name                   string
+	Authentication         string
+	Authorization          string
+	CacheTimeout           int
+	FlowType               string
+	Vendor                 string
+	AuthorizationServerURI string
+	TokenServerURI         string
+	ClientID               string
+	ClientSecret           string
+	RedirectURI            string
+	TokenType              string
+	UsernameAttribute      string
+	RoleAttribute          string
+	JWTIssuerURI           string
+	JWTAlgorithm           string
+	JWKSURI                string
+}
+
+type OAuthAppServerConfig struct {
+	Name                   string
+	Group                  string
+	Root                   string
+	Port                   int
+	ContentDatabase        string
+	ExternalSecurityName   string
+	TLSCertificateTemplate string
 }
 
 type managementClient struct {
@@ -452,6 +485,153 @@ func (c *managementClient) RemoveDynamicHost(ctx context.Context, clusterName, h
 	return err
 }
 
+// ImportCertificateAuthority inserts a PEM-encoded certificate authority into the Security database.
+func (c *managementClient) ImportCertificateAuthority(ctx context.Context, authorityPEM string) error {
+	if strings.TrimSpace(authorityPEM) == "" {
+		return fmt.Errorf("certificate authority PEM is required")
+	}
+	_, _, err := c.doPlainText(ctx, http.MethodPost, "/manage/v2/certificate-authorities", nil, authorityPEM, http.StatusCreated)
+	return err
+}
+
+func (c *managementClient) EnsureOAuthExternalSecurity(ctx context.Context, config OAuthExternalSecurityConfig) error {
+	query := url.Values{}
+	query.Set("format", "json")
+	_, statusCode, err := c.doJSON(ctx, http.MethodGet, "/manage/v2/external-security/"+url.PathEscape(config.Name), query, nil, http.StatusOK, http.StatusNotFound)
+	if err != nil {
+		return err
+	}
+
+	payload, err := BuildOAuthExternalSecurityPayload(config)
+	if err != nil {
+		return err
+	}
+	if statusCode == http.StatusNotFound {
+		_, _, err = c.doJSON(ctx, http.MethodPost, "/manage/v2/external-security", nil, payload, http.StatusCreated)
+		return err
+	}
+
+	_, _, err = c.doJSON(ctx, http.MethodPut, "/manage/v2/external-security/"+url.PathEscape(config.Name)+"/properties", nil, payload, http.StatusNoContent)
+	return err
+}
+
+func (c *managementClient) EnsureOAuthAppServer(ctx context.Context, config OAuthAppServerConfig) error {
+	if err := validateOAuthAppServerConfig(config); err != nil {
+		return err
+	}
+	query := url.Values{}
+	query.Set("group-id", config.Group)
+	query.Set("format", "json")
+	_, statusCode, err := c.doJSON(ctx, http.MethodGet, "/manage/v2/servers/"+url.PathEscape(config.Name), query, nil, http.StatusOK, http.StatusNotFound)
+	if err != nil {
+		return err
+	}
+
+	payload := BuildOAuthAppServerPayload(config)
+	if statusCode == http.StatusNotFound {
+		query.Set("server-type", "http")
+		_, _, err = c.doJSON(ctx, http.MethodPost, "/manage/v2/servers", query, payload, http.StatusCreated, http.StatusAccepted)
+		return err
+	}
+
+	_, _, err = c.doJSON(ctx, http.MethodPut, "/manage/v2/servers/"+url.PathEscape(config.Name)+"/properties", query, payload, http.StatusAccepted, http.StatusNoContent)
+	return err
+}
+
+// BuildOAuthExternalSecurityPayload returns the Management API representation for an OAuth external security configuration.
+func BuildOAuthExternalSecurityPayload(config OAuthExternalSecurityConfig) (map[string]any, error) {
+	if err := validateOAuthExternalSecurityConfig(config); err != nil {
+		return nil, err
+	}
+
+	oauthServer := map[string]string{
+		"oauth-flow-type":          config.FlowType,
+		"oauth-vendor":             config.Vendor,
+		"oauth-client-id":          config.ClientID,
+		"oauth-token-type":         config.TokenType,
+		"oauth-username-attribute": config.UsernameAttribute,
+		"oauth-role-attribute":     config.RoleAttribute,
+		"oauth-jwt-alg":            config.JWTAlgorithm,
+		"oauth-jwks-uri":           config.JWKSURI,
+	}
+	for field, value := range map[string]string{
+		"oauth-authorization-server-uri": config.AuthorizationServerURI,
+		"oauth-token-server-uri":         config.TokenServerURI,
+		"oauth-client-secret":            config.ClientSecret,
+		"oauth-redirect-uri":             config.RedirectURI,
+		"oauth-jwt-issuer-uri":           config.JWTIssuerURI,
+	} {
+		if strings.TrimSpace(value) != "" {
+			oauthServer[field] = value
+		}
+	}
+
+	return map[string]any{
+		"external-security-name": config.Name,
+		"authentication":         config.Authentication,
+		"authorization":          config.Authorization,
+		"cache-timeout":          config.CacheTimeout,
+		"oauth-server":           oauthServer,
+	}, nil
+}
+
+func validateOAuthExternalSecurityConfig(config OAuthExternalSecurityConfig) error {
+	for field, value := range map[string]string{
+		"name":                     config.Name,
+		"authentication":           config.Authentication,
+		"authorization":            config.Authorization,
+		"OAuth flow type":          config.FlowType,
+		"OAuth vendor":             config.Vendor,
+		"OAuth client ID":          config.ClientID,
+		"OAuth token type":         config.TokenType,
+		"OAuth username attribute": config.UsernameAttribute,
+		"OAuth role attribute":     config.RoleAttribute,
+		"OAuth JWT algorithm":      config.JWTAlgorithm,
+		"OAuth JWKS URI":           config.JWKSURI,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", field)
+		}
+	}
+	if config.CacheTimeout <= 0 {
+		return errors.New("OAuth cache timeout must be greater than zero")
+	}
+	return nil
+}
+
+// BuildOAuthAppServerPayload returns the Management API representation for an OAuth-protected HTTP App Server.
+func BuildOAuthAppServerPayload(config OAuthAppServerConfig) map[string]any {
+	return map[string]any{
+		"server-name":              config.Name,
+		"root":                     config.Root,
+		"port":                     config.Port,
+		"content-database":         config.ContentDatabase,
+		"authentication":           "oauth",
+		"internal-security":        false,
+		"external-security":        config.ExternalSecurityName,
+		"ssl-certificate-template": config.TLSCertificateTemplate,
+	}
+}
+
+func validateOAuthAppServerConfig(config OAuthAppServerConfig) error {
+	for field, value := range map[string]string{
+		"name":                     config.Name,
+		"group":                    config.Group,
+		"root":                     config.Root,
+		"content database":         config.ContentDatabase,
+		"external security":        config.ExternalSecurityName,
+		"TLS certificate template": config.TLSCertificateTemplate,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("OAuth App Server %s is required", field)
+		}
+	}
+	if config.Port < 1 || config.Port > 65535 {
+		return errors.New("OAuth App Server port must be between 1 and 65535")
+	}
+	return nil
+}
+
 func (c *managementClient) fetchClusterVersion(ctx context.Context) (string, error) {
 	query := url.Values{}
 	query.Set("format", "json")
@@ -543,6 +723,34 @@ func (c *managementClient) doXML(ctx context.Context, method, path string, query
 	}
 	statusCode = resp.StatusCode
 
+	for _, code := range expectedStatus {
+		if resp.StatusCode == code {
+			return data, resp.StatusCode, nil
+		}
+	}
+	return data, resp.StatusCode, fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data))
+}
+
+func (c *managementClient) doPlainText(ctx context.Context, method, path string, query url.Values, body string, expectedStatus ...int) (data []byte, statusCode int, err error) {
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint = endpoint + "?" + query.Encode()
+	}
+
+	headers := map[string]string{"Content-Type": "text/plain"}
+	resp, err := c.doRequestWithAuth(ctx, method, endpoint, headers, []byte(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		err = errors.Join(err, resp.Body.Close())
+	}()
+
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	statusCode = resp.StatusCode
 	for _, code := range expectedStatus {
 		if resp.StatusCode == code {
 			return data, resp.StatusCode, nil

--- a/pkg/mlmanage/client_test.go
+++ b/pkg/mlmanage/client_test.go
@@ -72,6 +72,49 @@ func TestRemoveDynamicHostUsesXMLBodyContract(t *testing.T) {
 	}
 }
 
+func TestImportCertificateAuthorityUsesPlainTextPEMContract(t *testing.T) {
+	t.Parallel()
+
+	const authorityPEM = "-----BEGIN CERTIFICATE-----\ntrusted-test-ca\n-----END CERTIFICATE-----\n"
+	var gotMethod string
+	var gotRequestURI string
+	var gotContentType string
+	var gotBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		gotMethod = r.Method
+		gotRequestURI = r.RequestURI
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody = string(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client := &managementClient{
+		baseURL:    server.URL,
+		username:   "user",
+		password:   "password",
+		httpClient: server.Client(),
+	}
+	if err := client.ImportCertificateAuthority(context.Background(), authorityPEM); err != nil {
+		t.Fatalf("ImportCertificateAuthority returned error: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotRequestURI != "/manage/v2/certificate-authorities" {
+		t.Fatalf("request = %s %s, want POST /manage/v2/certificate-authorities", gotMethod, gotRequestURI)
+	}
+	if gotContentType != "text/plain" {
+		t.Fatalf("Content-Type = %q, want text/plain", gotContentType)
+	}
+	if gotBody != authorityPEM {
+		t.Fatalf("request body = %q, want %q", gotBody, authorityPEM)
+	}
+}
+
 func TestRemoveDynamicHostEscapesXMLBodyText(t *testing.T) {
 	t.Parallel()
 
@@ -129,6 +172,171 @@ func TestRemoveDynamicHostReturnsAPIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "returned status 400") {
 		t.Fatalf("expected status detail in error, got %v", err)
+	}
+}
+
+func TestEnsureOAuthExternalSecurityCreatesConfiguration(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.RequestURI)
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPost:
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := &managementClient{
+		baseURL:    server.URL,
+		username:   "user",
+		password:   "password",
+		httpClient: server.Client(),
+	}
+	config := OAuthExternalSecurityConfig{
+		Name:              "oauth security",
+		Authentication:    "oauth",
+		Authorization:     "internal",
+		CacheTimeout:      300,
+		FlowType:          "Resource server",
+		Vendor:            "Other",
+		ClientID:          "marklogic-oauth-client",
+		TokenType:         "JSON Web Tokens",
+		UsernameAttribute: "preferred_username",
+		RoleAttribute:     "roles",
+		JWTIssuerURI:      "https://keycloak.example.test/realms/marklogic-oauth",
+		JWTAlgorithm:      "RS256",
+		JWKSURI:           "https://keycloak.example.test/certs",
+	}
+
+	if err := client.EnsureOAuthExternalSecurity(context.Background(), config); err != nil {
+		t.Fatalf("EnsureOAuthExternalSecurity returned error: %v", err)
+	}
+
+	if got := strings.Join(requests, ", "); got != "GET /manage/v2/external-security/oauth%20security?format=json, POST /manage/v2/external-security" {
+		t.Fatalf("unexpected requests: %s", got)
+	}
+	if gotBody["external-security-name"] != config.Name {
+		t.Fatalf("external-security-name = %v, want %q", gotBody["external-security-name"], config.Name)
+	}
+	if gotBody["cache-timeout"] != float64(config.CacheTimeout) {
+		t.Fatalf("cache-timeout = %v, want %d", gotBody["cache-timeout"], config.CacheTimeout)
+	}
+	oauthServer, ok := gotBody["oauth-server"].(map[string]any)
+	if !ok {
+		t.Fatalf("oauth-server = %#v, want object", gotBody["oauth-server"])
+	}
+	if _, found := oauthServer["oauth-authorization-server-uri"]; found {
+		t.Fatalf("resource-server payload must omit authorization endpoint: %#v", oauthServer)
+	}
+	if _, found := oauthServer["oauth-token-server-uri"]; found {
+		t.Fatalf("resource-server payload must omit token endpoint: %#v", oauthServer)
+	}
+	if _, found := oauthServer["oauth-redirect-uri"]; found {
+		t.Fatalf("resource-server payload must omit redirect URI: %#v", oauthServer)
+	}
+	if oauthServer["oauth-jwt-issuer-uri"] != config.JWTIssuerURI {
+		t.Fatalf("JWT issuer URI = %v, want %q", oauthServer["oauth-jwt-issuer-uri"], config.JWTIssuerURI)
+	}
+	if oauthServer["oauth-jwks-uri"] != config.JWKSURI {
+		t.Fatalf("JWKS URI = %v, want %q", oauthServer["oauth-jwks-uri"], config.JWKSURI)
+	}
+}
+
+func TestBuildOAuthExternalSecurityPayloadRejectsMissingRequiredField(t *testing.T) {
+	_, err := BuildOAuthExternalSecurityPayload(OAuthExternalSecurityConfig{
+		Name:           "oauth-security",
+		Authentication: "oauth",
+		Authorization:  "oauth",
+		CacheTimeout:   300,
+	})
+	if err == nil {
+		t.Fatal("BuildOAuthExternalSecurityPayload accepted an incomplete configuration")
+	}
+	if strings.TrimSpace(err.Error()) == "" {
+		t.Fatal("BuildOAuthExternalSecurityPayload returned an empty validation error")
+	}
+}
+
+func TestEnsureOAuthAppServerCreatesConfiguration(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.RequestURI)
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPost:
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := &managementClient{baseURL: server.URL, username: "user", password: "password", httpClient: server.Client()}
+	config := OAuthAppServerConfig{Name: "oauth app", Group: "Default", Root: "/", Port: 8013, ContentDatabase: "Documents", ExternalSecurityName: "keycloak-resource-server", TLSCertificateTemplate: "defaultTemplate"}
+	if err := client.EnsureOAuthAppServer(context.Background(), config); err != nil {
+		t.Fatalf("EnsureOAuthAppServer returned error: %v", err)
+	}
+
+	if got := strings.Join(requests, ", "); got != "GET /manage/v2/servers/oauth%20app?format=json&group-id=Default, POST /manage/v2/servers?format=json&group-id=Default&server-type=http" {
+		t.Fatalf("unexpected requests: %s", got)
+	}
+	if gotBody["authentication"] != "oauth" || gotBody["internal-security"] != false || gotBody["external-security"] != config.ExternalSecurityName || gotBody["ssl-certificate-template"] != config.TLSCertificateTemplate {
+		t.Fatalf("OAuth App Server payload = %#v", gotBody)
+	}
+}
+
+func TestEnsureOAuthAppServerUpdatesExistingConfiguration(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.RequestURI)
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := &managementClient{baseURL: server.URL, username: "user", password: "password", httpClient: server.Client()}
+	config := OAuthAppServerConfig{Name: "oauth app", Group: "Default", Root: "/", Port: 8013, ContentDatabase: "Documents", ExternalSecurityName: "keycloak-resource-server", TLSCertificateTemplate: "defaultTemplate"}
+	if err := client.EnsureOAuthAppServer(context.Background(), config); err != nil {
+		t.Fatalf("EnsureOAuthAppServer returned error: %v", err)
+	}
+
+	if got := strings.Join(requests, ", "); got != "GET /manage/v2/servers/oauth%20app?format=json&group-id=Default, PUT /manage/v2/servers/oauth%20app/properties?format=json&group-id=Default" {
+		t.Fatalf("unexpected requests: %s", got)
+	}
+	if gotBody["port"] != float64(config.Port) || gotBody["external-security"] != config.ExternalSecurityName {
+		t.Fatalf("OAuth App Server payload = %#v", gotBody)
 	}
 }
 

--- a/test/integration/marklogic-server/README.md
+++ b/test/integration/marklogic-server/README.md
@@ -1,0 +1,65 @@
+# MarkLogic Server Integration Tests
+
+Integration tests that exercise the operator against a **real MarkLogic cluster**
+running in Kubernetes, rather than mocking the Kubernetes API (as the unit tests
+under `internal/controller` do). These tests provision actual `MarklogicCluster`
+resources, wait for the operator to reconcile them, and then talk to the live
+MarkLogic server(s) — optionally alongside supporting infrastructure such as
+Keycloak and HAProxy — to validate end-to-end behavior.
+
+> These are **opt-in** tests, gated behind environment variables so they don't run
+> as part of the normal fast unit-test pass.
+
+## Prerequisites
+
+- A running Kubernetes cluster (minikube, kind, EKS, ...) selected by the current
+  `kubectl` context, with a default `StorageClass` that can provision
+  `PersistentVolumeClaim`s.
+- The MarkLogic operator installed in the cluster (the tests create
+  `MarklogicCluster` resources reconciled by the operator).
+- Go toolchain and access to pull the MarkLogic (and, for OAuth tests, Keycloak,
+  HAProxy, curl) images used by the fixtures.
+
+## Directory layout
+
+| Path | Purpose |
+| --- | --- |
+| [`oauth/`](oauth/README.md) | OAuth 2.0 (Authorization Code and Resource Server/JWT bearer) integration tests behind the operator-managed HAProxy load balancer, plus the HAProxy SessionID affinity contract test. See [oauth/README.md](oauth/README.md) for details. |
+| `fixtures/` | Reusable builders for Kubernetes objects used by the integration tests. |
+| `fixtures/marklogiccluster/` | Builds a `MarklogicCluster` custom resource (TLS-enabled, HAProxy-fronted, two-node) for a test namespace. |
+| `fixtures/keycloak/` | Builds the Keycloak `Deployment`/`Service` fixture and realm import used for OAuth tests. |
+| `fixtures/oauthclient/` | Builds an idle `curl` client `Pod` (with cookie jar and CA mounted) used to drive HTTP flows against MarkLogic/Keycloak from inside the cluster. |
+| `fixtures/tls/` | Generates a self-signed CA and server certificate/key, and builds the corresponding `Secret`s for TLS-enabled tests. |
+| `testutil/` | Shared test helpers: a Kubernetes scheme for decoding operator/core types, `kubectl`-based diagnostics collection, etc. |
+
+## Running the tests
+
+Each test suite is gated behind its own environment variable(s) — see the
+suite's own README (currently [oauth/README.md](oauth/README.md)) for the exact
+variables, namespaces, and `go test -run` invocations.
+
+General pattern:
+
+```sh
+<GATE_ENV_VAR>=true \
+MARKLOGIC_IMAGE=<marklogic-image> \
+go test -v -count=1 -timeout 45m \
+  -run <TestName> \
+  ./test/integration/marklogic-server/<suite>
+```
+
+## Cleanup
+
+Tests default to deleting their namespace on completion. Most suites support a
+`*_RETAIN_NAMESPACE=true` variable to keep the namespace around for inspection;
+remove it manually afterwards with:
+
+```sh
+kubectl delete ns <namespace>
+```
+
+## Diagnostics on failure
+
+`testutil.CollectKubernetesDiagnostics` is invoked on test failure to log pod,
+service, and event state plus container logs for the test namespace, which shows
+up directly in the `go test -v` output.

--- a/test/integration/marklogic-server/fixtures/keycloak/keycloak.go
+++ b/test/integration/marklogic-server/fixtures/keycloak/keycloak.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package keycloak
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	Image    = "quay.io/keycloak/keycloak:26.0.7"
+	Name     = "keycloak"
+	Realm    = "marklogic-oauth"
+	ClientID = "marklogic-oauth-client"
+	// AuthCodeClientID / AuthCodeClientSecret identify a dedicated confidential
+	// client used by the Authorization Code flow. MarkLogic 12.1 authenticates at
+	// the token endpoint with a client secret, so the Authorization Code client
+	// must be confidential while the public ClientID above keeps serving the
+	// resource-server (direct access grant) flows.
+	AuthCodeClientID     = "marklogic-oauth-authcode-client"
+	AuthCodeClientSecret = "marklogic-oauth-authcode-secret"
+	TestUsername         = "oauth-test-user"
+	TestUserPassword     = "oauth-test-password"
+	AdminUsername        = "oauth-test-admin"
+	AdminPassword        = "oauth-test-admin-password"
+	RealmConfigMapKey    = "realm-marklogic-oauth.json"
+)
+
+type Config struct {
+	Namespace     string
+	RedirectURI   string
+	IssuerURL     string
+	TLSSecretName string
+}
+
+type Resources struct {
+	AdminSecret    *corev1.Secret
+	RealmConfigMap *corev1.ConfigMap
+	Deployment     *appsv1.Deployment
+	Service        *corev1.Service
+}
+
+// Deploy applies the Keycloak fixture resources and waits for OpenID discovery to become ready.
+func Deploy(t *testing.T, config Config) {
+	t.Helper()
+	resources, err := BuildResources(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.ApplyObjects(t, resources.AdminSecret, resources.RealmConfigMap, resources.Deployment, resources.Service)
+	testutil.WaitForDeploymentAvailable(t, config.Namespace, Name, 3*time.Minute)
+}
+
+func BuildResources(config Config) (Resources, error) {
+	if config.Namespace == "" {
+		return Resources{}, fmt.Errorf("namespace is required")
+	}
+	if config.IssuerURL == "" {
+		return Resources{}, fmt.Errorf("issuer URL is required")
+	}
+	if config.TLSSecretName == "" {
+		return Resources{}, fmt.Errorf("TLS Secret name is required")
+	}
+
+	realmImport, err := json.Marshal(realmDefinition{RedirectURI: config.RedirectURI})
+	if err != nil {
+		return Resources{}, fmt.Errorf("marshal Keycloak realm import: %w", err)
+	}
+	labels := map[string]string{"app.kubernetes.io/name": Name}
+	replicas := int32(1)
+
+	return Resources{
+		AdminSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: Name + "-admin", Namespace: config.Namespace},
+			StringData: map[string]string{
+				"username": AdminUsername,
+				"password": AdminPassword,
+			},
+		},
+		RealmConfigMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: Name + "-realm", Namespace: config.Namespace},
+			Data:       map[string]string{RealmConfigMapKey: string(realmImport)},
+		},
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: Name, Namespace: config.Namespace, Labels: labels},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:    Name,
+							Image:   Image,
+							Command: []string{"/opt/keycloak/bin/kc.sh"},
+							Args: []string{
+								"start",
+								"--import-realm",
+								"--http-enabled=false",
+								"--https-port=8443",
+								"--https-certificate-file=/etc/x509/https/tls.crt",
+								"--https-certificate-key-file=/etc/x509/https/tls.key",
+								"--hostname=" + config.IssuerURL,
+							},
+							Env: []corev1.EnvVar{
+								{Name: "KC_BOOTSTRAP_ADMIN_USERNAME", ValueFrom: secretValue("username")},
+								{Name: "KC_BOOTSTRAP_ADMIN_PASSWORD", ValueFrom: secretValue("password")},
+							},
+							Ports: []corev1.ContainerPort{{Name: "https", ContainerPort: 8443}},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/realms/" + Realm + "/.well-known/openid-configuration", Port: intstr.FromInt(8443), Scheme: corev1.URISchemeHTTPS}},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "realm-import", MountPath: "/opt/keycloak/data/import", ReadOnly: true},
+								{Name: "https", MountPath: "/etc/x509/https", ReadOnly: true},
+							},
+						}},
+						Volumes: []corev1.Volume{
+							{
+								Name: "realm-import",
+								VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: Name + "-realm"},
+								}},
+							},
+							{Name: "https", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: config.TLSSecretName}}},
+						},
+					},
+				},
+			},
+		},
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: Name, Namespace: config.Namespace, Labels: labels},
+			Spec: corev1.ServiceSpec{
+				Selector: labels,
+				Ports:    []corev1.ServicePort{{Name: "https", Port: 8443, TargetPort: intstr.FromInt(8443)}},
+			},
+		},
+	}, nil
+}
+
+func secretValue(key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: Name + "-admin"},
+		Key:                  key,
+	}}
+}
+
+type realmDefinition struct {
+	Realm       string          `json:"realm"`
+	Enabled     bool            `json:"enabled"`
+	RedirectURI string          `json:"-"`
+	Clients     []realmClient   `json:"clients"`
+	Users       []realmTestUser `json:"users"`
+}
+
+func (definition realmDefinition) MarshalJSON() ([]byte, error) {
+	type payload realmDefinition
+	client := realmClient{ClientID: ClientID, Enabled: true, Protocol: "openid-connect", PublicClient: true, DirectAccessGrantsEnabled: true, StandardFlowEnabled: true}
+	// A confidential client for the Authorization Code flow: MarkLogic 12.1 sends
+	// a client secret when exchanging the authorization code at the token endpoint.
+	authCodeClient := realmClient{ClientID: AuthCodeClientID, Enabled: true, Protocol: "openid-connect", PublicClient: false, Secret: AuthCodeClientSecret, StandardFlowEnabled: true}
+	if definition.RedirectURI != "" {
+		client.RedirectURIs = []string{definition.RedirectURI}
+		authCodeClient.RedirectURIs = []string{definition.RedirectURI}
+	}
+	return json.Marshal(payload{
+		Realm:   Realm,
+		Enabled: true,
+		Clients: []realmClient{client, authCodeClient},
+		Users:   []realmTestUser{{Username: TestUsername, FirstName: "OAuth", LastName: "Test", Email: TestUsername + "@example.test", Enabled: true, EmailVerified: true, Credentials: []realmCredential{{Type: "password", Value: TestUserPassword, Temporary: false}}}},
+	})
+}
+
+type realmClient struct {
+	ClientID                  string   `json:"clientId"`
+	Enabled                   bool     `json:"enabled"`
+	Protocol                  string   `json:"protocol"`
+	PublicClient              bool     `json:"publicClient"`
+	Secret                    string   `json:"secret,omitempty"`
+	DirectAccessGrantsEnabled bool     `json:"directAccessGrantsEnabled"`
+	StandardFlowEnabled       bool     `json:"standardFlowEnabled"`
+	RedirectURIs              []string `json:"redirectUris,omitempty"`
+}
+
+type realmTestUser struct {
+	Username      string            `json:"username"`
+	FirstName     string            `json:"firstName"`
+	LastName      string            `json:"lastName"`
+	Email         string            `json:"email"`
+	Enabled       bool              `json:"enabled"`
+	EmailVerified bool              `json:"emailVerified"`
+	Credentials   []realmCredential `json:"credentials"`
+}
+
+type realmCredential struct {
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	Temporary bool   `json:"temporary"`
+}

--- a/test/integration/marklogic-server/fixtures/keycloak/keycloak_test.go
+++ b/test/integration/marklogic-server/fixtures/keycloak/keycloak_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package keycloak
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildResources(t *testing.T) {
+	resources, err := BuildResources(Config{
+		Namespace:     "oauth-test",
+		RedirectURI:   "https://oauth.example.test/callback",
+		IssuerURL:     "https://keycloak.oauth-test.svc.cluster.local:8443",
+		TLSSecretName: "keycloak-tls",
+	})
+	if err != nil {
+		t.Fatalf("BuildResources returned an error: %v", err)
+	}
+	if resources.Deployment.Spec.Template.Spec.Containers[0].Image != Image {
+		t.Fatalf("Keycloak image = %q, want %q", resources.Deployment.Spec.Template.Spec.Containers[0].Image, Image)
+	}
+	realm := resources.RealmConfigMap.Data[RealmConfigMapKey]
+	if !strings.Contains(realm, "https://oauth.example.test/callback") {
+		t.Fatalf("realm import does not include the redirect URI: %s", realm)
+	}
+	if !strings.Contains(realm, `"directAccessGrantsEnabled":true`) {
+		t.Fatalf("realm import does not enable direct access grants: %s", realm)
+	}
+	if !strings.Contains(realm, `"emailVerified":true`) {
+		t.Fatalf("realm import does not mark the disposable user as fully configured: %s", realm)
+	}
+	if !strings.Contains(realm, `"email":"oauth-test-user@example.test"`) {
+		t.Fatalf("realm import does not provide the disposable user email: %s", realm)
+	}
+	if !strings.Contains(realm, `"firstName":"OAuth"`) || !strings.Contains(realm, `"lastName":"Test"`) {
+		t.Fatalf("realm import does not provide the disposable user name: %s", realm)
+	}
+	container := resources.Deployment.Spec.Template.Spec.Containers[0]
+	if !contains(container.Args, "--http-enabled=false") || !contains(container.Args, "--https-port=8443") {
+		t.Fatalf("Keycloak args = %#v, want HTTPS-only configuration", container.Args)
+	}
+	if !contains(container.Args, "--hostname=https://keycloak.oauth-test.svc.cluster.local:8443") {
+		t.Fatalf("Keycloak args = %#v, want issuer URL hostname", container.Args)
+	}
+	if len(container.VolumeMounts) != 2 || container.VolumeMounts[1].MountPath != "/etc/x509/https" {
+		t.Fatalf("Keycloak volume mounts = %#v, want realm import and TLS Secret", container.VolumeMounts)
+	}
+	if resources.Service.Spec.Ports[0].Port != 8443 || resources.Service.Spec.Ports[0].TargetPort.IntValue() != 8443 {
+		t.Fatalf("Keycloak Service port = %#v, want HTTPS port 8443", resources.Service.Spec.Ports)
+	}
+}
+
+func TestBuildResourcesRequiresNamespaceIssuerAndTLSSecret(t *testing.T) {
+	validConfig := Config{
+		Namespace:     "oauth-test",
+		RedirectURI:   "https://oauth.example.test/callback",
+		IssuerURL:     "https://keycloak.oauth-test.svc.cluster.local:8443",
+		TLSSecretName: "keycloak-tls",
+	}
+	if _, err := BuildResources(Config{RedirectURI: validConfig.RedirectURI, IssuerURL: validConfig.IssuerURL, TLSSecretName: validConfig.TLSSecretName}); err == nil {
+		t.Fatal("BuildResources accepted an empty namespace")
+	}
+	resources, err := BuildResources(Config{Namespace: validConfig.Namespace, IssuerURL: validConfig.IssuerURL, TLSSecretName: validConfig.TLSSecretName})
+	if err != nil {
+		t.Fatalf("BuildResources rejected a resource-server client without a redirect URI: %v", err)
+	}
+	if realm := resources.RealmConfigMap.Data[RealmConfigMapKey]; strings.Contains(realm, "redirectUris") {
+		t.Fatalf("resource-server realm client unexpectedly includes redirect URIs: %s", realm)
+	}
+	if _, err := BuildResources(Config{Namespace: validConfig.Namespace, TLSSecretName: validConfig.TLSSecretName}); err == nil {
+		t.Fatal("BuildResources accepted an empty issuer URL")
+	}
+	if _, err := BuildResources(Config{Namespace: validConfig.Namespace, IssuerURL: validConfig.IssuerURL}); err == nil {
+		t.Fatal("BuildResources accepted an empty TLS Secret name")
+	}
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/marklogic-server/fixtures/marklogiccluster/marklogiccluster.go
+++ b/test/integration/marklogic-server/fixtures/marklogiccluster/marklogiccluster.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package marklogiccluster
+
+import (
+	"fmt"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DefaultImage = "progressofficial/marklogic-db:12.0.3-ubi9-rootless-2.2.6"
+	DefaultName  = "marklogic"
+)
+
+type Config struct {
+	Namespace              string
+	Name                   string
+	Image                  string
+	AdminUsername          string
+	AdminPassword          string
+	CASecretName           string
+	CertificateSecretNames []string
+}
+
+// Build creates a two-node TLS-enabled MarklogicCluster with operator-managed HAProxy.
+func Build(config Config) (*marklogicv1.MarklogicCluster, error) {
+	if config.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if config.AdminUsername == "" || config.AdminPassword == "" {
+		return nil, fmt.Errorf("admin username and password are required")
+	}
+	if config.CASecretName == "" {
+		return nil, fmt.Errorf("CA Secret name is required")
+	}
+	if len(config.CertificateSecretNames) != 2 {
+		return nil, fmt.Errorf("exactly two certificate Secret names are required")
+	}
+	name := config.Name
+	if name == "" {
+		name = DefaultName
+	}
+	image := config.Image
+	if image == "" {
+		image = DefaultImage
+	}
+	replicas := int32(2)
+
+	return &marklogicv1.MarklogicCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "marklogic.progress.com/v1", Kind: "MarklogicCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: config.Namespace},
+		Spec: marklogicv1.MarklogicClusterSpec{
+			Image: image,
+			Auth: &marklogicv1.AdminAuth{
+				AdminUsername: &config.AdminUsername,
+				AdminPassword: &config.AdminPassword,
+			},
+			MarkLogicGroups: []*marklogicv1.MarklogicGroups{{
+				Name:        name,
+				Replicas:    &replicas,
+				IsBootstrap: true,
+			}},
+			Tls: &marklogicv1.Tls{
+				EnableOnDefaultAppServers: true,
+				CaSecretName:              config.CASecretName,
+				CertSecretNames:           config.CertificateSecretNames,
+			},
+			HAProxy: &marklogicv1.HAProxy{
+				Enabled:      true,
+				ReplicaCount: 1,
+				FrontendPort: 8000,
+				AppServers: []marklogicv1.AppServers{
+					{Name: "app-services", Port: 8000},
+					{Name: "manage", Port: 8002},
+				},
+			},
+		},
+	}, nil
+}

--- a/test/integration/marklogic-server/fixtures/marklogiccluster/marklogiccluster_test.go
+++ b/test/integration/marklogic-server/fixtures/marklogiccluster/marklogiccluster_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package marklogiccluster
+
+import "testing"
+
+func TestBuildCreatesTwoNodeTLSHAProxyTopology(t *testing.T) {
+	cluster, err := Build(Config{
+		Namespace:              "oauth-test",
+		AdminUsername:          "admin",
+		AdminPassword:          "Admin@8001",
+		CASecretName:           "test-ca",
+		CertificateSecretNames: []string{"marklogic-0-tls", "marklogic-1-tls"},
+	})
+	if err != nil {
+		t.Fatalf("Build returned an error: %v", err)
+	}
+	if cluster.Spec.Image != DefaultImage {
+		t.Fatalf("Image = %q, want %q", cluster.Spec.Image, DefaultImage)
+	}
+	if len(cluster.Spec.MarkLogicGroups) != 1 || cluster.Spec.MarkLogicGroups[0].Replicas == nil || *cluster.Spec.MarkLogicGroups[0].Replicas != 2 {
+		t.Fatalf("MarkLogic groups = %#v, want one group with two replicas", cluster.Spec.MarkLogicGroups)
+	}
+	if !cluster.Spec.MarkLogicGroups[0].IsBootstrap {
+		t.Fatal("MarkLogic group is not the bootstrap group")
+	}
+	if cluster.Spec.Tls == nil || cluster.Spec.Tls.CaSecretName != "test-ca" || len(cluster.Spec.Tls.CertSecretNames) != 2 {
+		t.Fatalf("TLS configuration = %#v, want configured CA and two certificate Secrets", cluster.Spec.Tls)
+	}
+	if cluster.Spec.HAProxy == nil || !cluster.Spec.HAProxy.Enabled || cluster.Spec.HAProxy.FrontendPort != 8000 {
+		t.Fatalf("HAProxy configuration = %#v, want enabled HAProxy on port 8000", cluster.Spec.HAProxy)
+	}
+}
+
+func TestBuildRequiresTopologyConfiguration(t *testing.T) {
+	validConfig := Config{
+		Namespace:              "oauth-test",
+		AdminUsername:          "admin",
+		AdminPassword:          "Admin@8001",
+		CASecretName:           "test-ca",
+		CertificateSecretNames: []string{"marklogic-0-tls", "marklogic-1-tls"},
+	}
+	for name, config := range map[string]Config{
+		"namespace":                {AdminUsername: validConfig.AdminUsername, AdminPassword: validConfig.AdminPassword, CASecretName: validConfig.CASecretName, CertificateSecretNames: validConfig.CertificateSecretNames},
+		"admin credentials":        {Namespace: validConfig.Namespace, CASecretName: validConfig.CASecretName, CertificateSecretNames: validConfig.CertificateSecretNames},
+		"CA Secret":                {Namespace: validConfig.Namespace, AdminUsername: validConfig.AdminUsername, AdminPassword: validConfig.AdminPassword, CertificateSecretNames: validConfig.CertificateSecretNames},
+		"certificate Secret names": {Namespace: validConfig.Namespace, AdminUsername: validConfig.AdminUsername, AdminPassword: validConfig.AdminPassword, CASecretName: validConfig.CASecretName},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Build(config); err == nil {
+				t.Fatal("Build accepted an incomplete topology configuration")
+			}
+		})
+	}
+}

--- a/test/integration/marklogic-server/fixtures/oauthclient/oauthclient.go
+++ b/test/integration/marklogic-server/fixtures/oauthclient/oauthclient.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauthclient
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DefaultImage  = "curlimages/curl:8.12.1"
+	DefaultName   = "oauth-client"
+	CAPath        = "/etc/oauth-test/ca/cacert.pem"
+	CookieJarPath = "/work/cookies.txt"
+)
+
+type Config struct {
+	Namespace    string
+	Name         string
+	Image        string
+	CASecretName string
+}
+
+// Build creates an idle curl client Pod with a persistent cookie jar and the test CA mounted.
+func Build(config Config) (*corev1.Pod, error) {
+	if config.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	if config.CASecretName == "" {
+		return nil, fmt.Errorf("CA Secret name is required")
+	}
+	name := config.Name
+	if name == "" {
+		name = DefaultName
+	}
+	image := config.Image
+	if image == "" {
+		image = DefaultImage
+	}
+	labels := map[string]string{"app.kubernetes.io/name": name}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: config.Namespace, Labels: labels},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "curl",
+				Image:   image,
+				Command: []string{"sleep", "infinity"},
+				Env:     []corev1.EnvVar{{Name: "CURL_CA_BUNDLE", Value: CAPath}},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "test-ca", MountPath: "/etc/oauth-test/ca", ReadOnly: true},
+					{Name: "work", MountPath: "/work"},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "test-ca", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: config.CASecretName}}},
+				{Name: "work", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}, nil
+}

--- a/test/integration/marklogic-server/fixtures/oauthclient/oauthclient_test.go
+++ b/test/integration/marklogic-server/fixtures/oauthclient/oauthclient_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauthclient
+
+import "testing"
+
+func TestBuildCreatesTrustedCookieJarClient(t *testing.T) {
+	pod, err := Build(Config{Namespace: "oauth-test", CASecretName: "test-ca"})
+	if err != nil {
+		t.Fatalf("Build returned an error: %v", err)
+	}
+	container := pod.Spec.Containers[0]
+	if container.Image != DefaultImage {
+		t.Fatalf("image = %q, want %q", container.Image, DefaultImage)
+	}
+	if len(container.Command) != 2 || container.Command[0] != "sleep" || container.Command[1] != "infinity" {
+		t.Fatalf("command = %#v, want an idle sleep command", container.Command)
+	}
+	if container.Env[0].Name != "CURL_CA_BUNDLE" || container.Env[0].Value != CAPath {
+		t.Fatalf("CURL_CA_BUNDLE = %#v, want %q", container.Env, CAPath)
+	}
+	if len(container.VolumeMounts) != 2 || container.VolumeMounts[1].MountPath != "/work" {
+		t.Fatalf("volume mounts = %#v, want CA and cookie work volumes", container.VolumeMounts)
+	}
+}
+
+func TestBuildRequiresNamespaceAndCASecret(t *testing.T) {
+	if _, err := Build(Config{CASecretName: "test-ca"}); err == nil {
+		t.Fatal("Build accepted an empty namespace")
+	}
+	if _, err := Build(Config{Namespace: "oauth-test"}); err == nil {
+		t.Fatal("Build accepted an empty CA Secret name")
+	}
+}

--- a/test/integration/marklogic-server/fixtures/tls/tls.go
+++ b/test/integration/marklogic-server/fixtures/tls/tls.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const caCertificateKey = "cacert.pem"
+
+type Config struct {
+	Namespace     string
+	CASecretName  string
+	TLSSecretName string
+	DNSNames      []string
+}
+
+type Resources struct {
+	CASecret  *corev1.Secret
+	TLSSecret *corev1.Secret
+}
+
+type ClusterConfig struct {
+	Namespace    string
+	CASecretName string
+	Servers      []ServerConfig
+}
+
+type ServerConfig struct {
+	TLSSecretName string
+	DNSNames      []string
+	// PEMFileName, when set, produces an Opaque Secret whose single data key is
+	// PEMFileName and whose value is the concatenated certificate and private
+	// key PEM. HAProxy's `crt` directive expects this combined-PEM form.
+	PEMFileName string
+}
+
+type ClusterResources struct {
+	CASecret   *corev1.Secret
+	TLSSecrets []*corev1.Secret
+}
+
+// BuildResources creates a short-lived test CA and a TLS server certificate for the supplied DNS names.
+func BuildResources(config Config) (Resources, error) {
+	clusterResources, err := BuildClusterResources(ClusterConfig{
+		Namespace:    config.Namespace,
+		CASecretName: config.CASecretName,
+		Servers:      []ServerConfig{{TLSSecretName: config.TLSSecretName, DNSNames: config.DNSNames}},
+	})
+	if err != nil {
+		return Resources{}, err
+	}
+	return Resources{CASecret: clusterResources.CASecret, TLSSecret: clusterResources.TLSSecrets[0]}, nil
+}
+
+// BuildClusterResources creates a test CA and TLS Secrets for multiple servers signed by that CA.
+func BuildClusterResources(config ClusterConfig) (ClusterResources, error) {
+	if config.Namespace == "" {
+		return ClusterResources{}, fmt.Errorf("namespace is required")
+	}
+	if config.CASecretName == "" {
+		return ClusterResources{}, fmt.Errorf("CA Secret name is required")
+	}
+	if len(config.Servers) == 0 {
+		return ClusterResources{}, fmt.Errorf("at least one server is required")
+	}
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return ClusterResources{}, fmt.Errorf("generate CA key: %w", err)
+	}
+	caTemplate, err := certificateTemplate("MarkLogic Server integration test CA", true)
+	if err != nil {
+		return ClusterResources{}, err
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return ClusterResources{}, fmt.Errorf("create CA certificate: %w", err)
+	}
+	caCertificate, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return ClusterResources{}, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	resources := ClusterResources{
+		CASecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: config.CASecretName, Namespace: config.Namespace},
+			Data:       map[string][]byte{caCertificateKey: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})},
+		},
+	}
+	for _, server := range config.Servers {
+		secret, err := serverSecret(config.Namespace, server, caCertificate, caKey)
+		if err != nil {
+			return ClusterResources{}, err
+		}
+		resources.TLSSecrets = append(resources.TLSSecrets, secret)
+	}
+	return resources, nil
+}
+
+func serverSecret(namespace string, config ServerConfig, caCertificate *x509.Certificate, caKey *rsa.PrivateKey) (*corev1.Secret, error) {
+	if config.TLSSecretName == "" {
+		return nil, fmt.Errorf("TLS Secret name is required")
+	}
+	if len(config.DNSNames) == 0 {
+		return nil, fmt.Errorf("at least one DNS name is required")
+	}
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate server key: %w", err)
+	}
+	serverTemplate, err := certificateTemplate(config.DNSNames[0], false)
+	if err != nil {
+		return nil, err
+	}
+	serverTemplate.DNSNames = config.DNSNames
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCertificate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create server certificate: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	if config.PEMFileName != "" {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: config.TLSSecretName, Namespace: namespace},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{config.PEMFileName: append(append([]byte{}, certPEM...), keyPEM...)},
+		}, nil
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: config.TLSSecretName, Namespace: namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}, nil
+}
+
+func certificateTemplate(commonName string, isCA bool) (*x509.Certificate, error) {
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generate certificate serial number: %w", err)
+	}
+	return &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+	}, nil
+}

--- a/test/integration/marklogic-server/fixtures/tls/tls_test.go
+++ b/test/integration/marklogic-server/fixtures/tls/tls_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package tls
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildResourcesCreatesTrustedServerCertificate(t *testing.T) {
+	resources, err := BuildResources(Config{
+		Namespace:     "oauth-test",
+		CASecretName:  "test-ca",
+		TLSSecretName: "oauth-server-tls",
+		DNSNames:      []string{"oauth.example.test", "oauth"},
+	})
+	if err != nil {
+		t.Fatalf("BuildResources returned an error: %v", err)
+	}
+	if resources.TLSSecret.Type != corev1.SecretTypeTLS {
+		t.Fatalf("TLS Secret type = %q, want %q", resources.TLSSecret.Type, corev1.SecretTypeTLS)
+	}
+	certificateBlock, _ := pem.Decode(resources.TLSSecret.Data[corev1.TLSCertKey])
+	if certificateBlock == nil {
+		t.Fatal("TLS Secret does not contain a PEM certificate")
+	}
+	certificate, err := x509.ParseCertificate(certificateBlock.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate returned an error: %v", err)
+	}
+	if err := certificate.VerifyHostname("oauth.example.test"); err != nil {
+		t.Fatalf("server certificate does not trust oauth.example.test: %v", err)
+	}
+	if len(resources.CASecret.Data[caCertificateKey]) == 0 {
+		t.Fatal("CA Secret does not contain a CA certificate")
+	}
+}
+
+func TestBuildResourcesRequiresTLSConfiguration(t *testing.T) {
+	validConfig := Config{Namespace: "oauth-test", CASecretName: "test-ca", TLSSecretName: "server-tls", DNSNames: []string{"oauth"}}
+	for name, config := range map[string]Config{
+		"namespace":  {CASecretName: validConfig.CASecretName, TLSSecretName: validConfig.TLSSecretName, DNSNames: validConfig.DNSNames},
+		"CA Secret":  {Namespace: validConfig.Namespace, TLSSecretName: validConfig.TLSSecretName, DNSNames: validConfig.DNSNames},
+		"TLS Secret": {Namespace: validConfig.Namespace, CASecretName: validConfig.CASecretName, DNSNames: validConfig.DNSNames},
+		"DNS name":   {Namespace: validConfig.Namespace, CASecretName: validConfig.CASecretName, TLSSecretName: validConfig.TLSSecretName},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildResources(config); err == nil {
+				t.Fatal("BuildResources accepted an incomplete TLS configuration")
+			}
+		})
+	}
+}
+
+func TestBuildClusterResourcesIssuesAllCertificatesFromOneCA(t *testing.T) {
+	resources, err := BuildClusterResources(ClusterConfig{
+		Namespace:    "oauth-test",
+		CASecretName: "test-ca",
+		Servers: []ServerConfig{
+			{TLSSecretName: "marklogic-0-tls", DNSNames: []string{"marklogic-0"}},
+			{TLSSecretName: "marklogic-1-tls", DNSNames: []string{"marklogic-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildClusterResources returned an error: %v", err)
+	}
+	if len(resources.TLSSecrets) != 2 {
+		t.Fatalf("TLS Secret count = %d, want 2", len(resources.TLSSecrets))
+	}
+	caBlock, _ := pem.Decode(resources.CASecret.Data[caCertificateKey])
+	if caBlock == nil {
+		t.Fatal("CA Secret does not contain a PEM certificate")
+	}
+	caCertificate, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate for CA returned an error: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(caCertificate)
+	for index, secret := range resources.TLSSecrets {
+		certificateBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+		certificate, err := x509.ParseCertificate(certificateBlock.Bytes)
+		if err != nil {
+			t.Fatalf("ParseCertificate for server %d returned an error: %v", index, err)
+		}
+		if _, err := certificate.Verify(x509.VerifyOptions{Roots: roots, DNSName: certificate.DNSNames[0]}); err != nil {
+			t.Fatalf("server certificate %d is not trusted by the generated CA: %v", index, err)
+		}
+	}
+}

--- a/test/integration/marklogic-server/oauth/README.md
+++ b/test/integration/marklogic-server/oauth/README.md
@@ -1,0 +1,125 @@
+# OAuth Integration Tests
+
+Integration tests that validate MarkLogic OAuth 2.0 authentication behind the
+operator-managed HAProxy load balancer, running against a disposable, in-cluster
+[Keycloak](https://www.keycloak.org/) identity provider.
+
+These tests provision a real two-node MarkLogic cluster, HAProxy, and Keycloak in
+a Kubernetes namespace, wire up TLS end to end, configure MarkLogic external
+security plus an OAuth App Server through the Management API, and then exercise the
+OAuth flows through the load balancer.
+
+> These are **opt-in** tests. Each is gated behind an environment variable and is
+> skipped by default so it does not run in the normal unit-test pass.
+
+## Prerequisites
+
+- A running Kubernetes cluster (minikube, kind, EKS, ...) selected by the current
+  `kubectl` context, with a default `StorageClass` that can provision
+  `PersistentVolumeClaim`s.
+- The MarkLogic operator installed in the cluster (the tests create
+  `MarklogicCluster` resources reconciled by the operator).
+- Go toolchain and access to pull the MarkLogic, Keycloak, HAProxy, and curl
+  images used by the fixtures.
+- For the Authorization Code test, a **MarkLogic 12.1+** image (the Authorization
+  Code flow is rejected on 12.0.x).
+
+## Test suites
+
+| Test | Gate env var | Namespace | What it covers |
+| --- | --- | --- | --- |
+| `TestOAuthAuthorizationCodeInfrastructure` | `MARKLOGIC_OAUTH_AUTHORIZATION_CODE=true` | `ml-oauth-authorization-code` | Full OAuth 2.0 Authorization Code (PKCE) flow through HAProxy with SessionID affinity. |
+| `TestOAuthResourceServerInfrastructure` | `MARKLOGIC_OAUTH_RESOURCE_SERVER=true` | `ml-oauth-session-affinity` | Resource-server (JWT bearer) external security + OAuth App Server setup. |
+| `TestHAProxySessionIDAffinityContract` | `MARKLOGIC_HAPROXY_SESSION_AFFINITY=true` | `ml-haproxy-session-affinity` | HAProxy native SessionID cookie affinity contract, using nginx backends (no MarkLogic). |
+
+The unit tests in `oauth_setup_test.go` run without any gate and validate helper
+logic (OpenID discovery parsing, redirect-URI validation, etc.).
+
+## Environment variables
+
+| Variable | Required for | Purpose |
+| --- | --- | --- |
+| `MARKLOGIC_OAUTH_AUTHORIZATION_CODE` | Authorization Code test | Set to `true` to enable the test. |
+| `MARKLOGIC_OAUTH_RESOURCE_SERVER` | Resource-server test | Set to `true` to enable the test. |
+| `MARKLOGIC_HAPROXY_SESSION_AFFINITY` | Affinity contract test | Set to `true` to enable the test. |
+| `MARKLOGIC_IMAGE` | Authorization Code test (12.1+) | MarkLogic server image to deploy. Required for the Authorization Code flow. |
+| `MARKLOGIC_OAUTH_REDIRECT_URI` | optional | Overrides the OAuth redirect/callback URI advertised to Keycloak. |
+| `MARKLOGIC_OAUTH_RETAIN_NAMESPACE` | optional | Set to `true` to keep the namespace after the test for inspection instead of deleting it. |
+
+## Running the tests
+
+### Authorization Code flow (MarkLogic 12.1+)
+
+```sh
+MARKLOGIC_OAUTH_AUTHORIZATION_CODE=true \
+MARKLOGIC_IMAGE=<your-marklogic-12.1+-image> \
+MARKLOGIC_OAUTH_RETAIN_NAMESPACE=true \
+go test -v -count=1 -timeout 45m \
+  -run TestOAuthAuthorizationCodeInfrastructure \
+  ./test/integration/marklogic-server/oauth
+```
+
+Sub-cases (from `docs/test/OAuth Test Spec.md`):
+
+- **TC1 – SessionID before authentication:** the OAuth App Server sets a
+  `SessionID` cookie and redirects to Keycloak with an Authorization Code + PKCE
+  request before the user authenticates.
+- **TC2 – affinity completes flow:** with HAProxy `SessionID` affinity, the IdP
+  callback returns to the same node that started the flow, so the code exchange
+  (using the confidential client secret) succeeds.
+- **TC3 – cross-node callback fails:** a callback delivered to a different node
+  fails, because the in-flight PKCE verifier and OAuth `state` are node-local
+  (MarkLogic reports `XDMP-OAUTH: Novel OAuth state ... potential CSRF attack`).
+  This proves affinity is required.
+
+### Resource-server (JWT bearer)
+
+```sh
+MARKLOGIC_OAUTH_RESOURCE_SERVER=true \
+go test -v -count=1 -timeout 45m \
+  -run TestOAuthResourceServerInfrastructure \
+  ./test/integration/marklogic-server/oauth
+```
+
+### HAProxy SessionID affinity contract
+
+```sh
+MARKLOGIC_HAPROXY_SESSION_AFFINITY=true \
+go test -v -count=1 -timeout 20m \
+  -run TestHAProxySessionIDAffinityContract \
+  ./test/integration/marklogic-server/oauth
+```
+
+## Keycloak fixture
+
+The Keycloak realm `marklogic-oauth` is imported at startup with two clients:
+
+- `marklogic-oauth-client` — a **public** client with direct access grants
+  enabled, used by the resource-server (password grant) flow.
+- `marklogic-oauth-authcode-client` — a **confidential** client (with a secret)
+  used by the Authorization Code flow, because MarkLogic 12.1 authenticates at the
+  token endpoint with a client secret when exchanging the authorization code.
+
+A disposable test user `oauth-test-user` is seeded for authentication.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `oauth_setup.go` | Shared infrastructure builder (TLS, Keycloak, MarkLogic cluster, HAProxy, client pod) and external-security / App Server config. |
+| `oauth_setup_test.go` | Unit tests for the setup helpers. |
+| `oauth_authorization_code_test.go` | Authorization Code flow test (TC1/TC2/TC3). |
+| `oauth_load_balancer_affinity_test.go` | Resource-server external security + OAuth App Server setup test. |
+| `session_affinity_test.go` | HAProxy SessionID affinity contract test using nginx backends. |
+
+## Cleanup
+
+By default each test deletes its namespace on completion. Set
+`MARKLOGIC_OAUTH_RETAIN_NAMESPACE=true` to retain it for inspection, then remove it
+manually when finished:
+
+```sh
+kubectl delete ns ml-oauth-authorization-code
+kubectl delete ns ml-oauth-session-affinity
+kubectl delete ns ml-haproxy-session-affinity
+```

--- a/test/integration/marklogic-server/oauth/oauth_authorization_code_test.go
+++ b/test/integration/marklogic-server/oauth/oauth_authorization_code_test.go
@@ -310,7 +310,7 @@ const authCodeFlowScript = `
 START_URL="$1"; CALLBACK_BASE="$2"; USER="$3"; PASS="$4"; CARRY="$5"
 JAR=$(mktemp); KCJAR=$(mktemp)
 
-H1=$(curl -sk -c "$JAR" -D - -o /dev/null "$START_URL")
+H1=$(curl -sS --fail -c "$JAR" -D - -o /dev/null "$START_URL")
 echo "STEP1_STATUS=$(printf '%s' "$H1" | head -1 | tr -d '\r')"
 LOC=$(printf '%s' "$H1" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2; exit}')
 SID=$(awk '$6=="SessionID"{v=$7} END{print v}' "$JAR")

--- a/test/integration/marklogic-server/oauth/oauth_authorization_code_test.go
+++ b/test/integration/marklogic-server/oauth/oauth_authorization_code_test.go
@@ -1,0 +1,355 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marklogic/marklogic-operator-kubernetes/pkg/mlmanage"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/keycloak"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/oauthclient"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/testutil"
+)
+
+const oauthAuthCodeNamespace = "ml-oauth-authorization-code"
+
+// TestOAuthAuthorizationCodeInfrastructure exercises the OAuth 2.0 Authorization
+// Code flow behind the operator-managed HAProxy load balancer on MarkLogic 12.1+,
+// where the flow is supported. It configures an Authorization Code external
+// security and OAuth App Server, then runs the load-balancer session-affinity
+// test cases from docs/test/OAuth Test Spec.md:
+//
+//	TC1 - the OAuth App Server sets a SessionID cookie and redirects to the IdP
+//	      before authentication.
+//	TC2 - with HAProxy SessionID affinity, the callback returns to the initiating
+//	      node and the flow completes.
+//	TC3 - a callback delivered to a different node fails because the in-flight
+//	      PKCE/state is node-local.
+func TestOAuthAuthorizationCodeInfrastructure(t *testing.T) {
+	if !authCodeTestEnabledFromEnvironment() {
+		t.Skipf("set %s=true to run the OAuth Authorization Code infrastructure test", oauthAuthCodeTestEnvironment)
+	}
+	image := marklogicImageFromEnvironment()
+	if image == "" {
+		t.Fatalf("set %s to a MarkLogic 12.1+ image; the Authorization Code flow is deprecated/rejected on 12.0.x", marklogicImageEnvironment)
+	}
+	redirectURI := authCodeRedirectURI(oauthAuthCodeNamespace)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			testutil.CollectKubernetesDiagnostics(t, oauthAuthCodeNamespace)
+		}
+		if retainNamespaceFromEnvironment() {
+			t.Logf("Retaining namespace %s because %s=true", oauthAuthCodeNamespace, oauthRetainNamespaceEnvironment)
+			return
+		}
+		testutil.DeleteNamespace(t, oauthAuthCodeNamespace)
+	})
+
+	infrastructure := DeployInfrastructure(t, InfrastructureConfig{
+		Namespace:   oauthAuthCodeNamespace,
+		RedirectURI: redirectURI,
+		Image:       image,
+	})
+	testutil.WaitForStatefulSetReady(t, oauthAuthCodeNamespace, infrastructure.Cluster.Name, 15*time.Minute)
+	testutil.WaitForDeploymentAvailable(t, oauthAuthCodeNamespace, haproxyServiceName, 5*time.Minute)
+	testutil.WaitForDeploymentAvailable(t, oauthAuthCodeNamespace, keycloak.Name, 5*time.Minute)
+	testutil.WaitForPodReady(t, oauthAuthCodeNamespace, oauthclient.DefaultName, 2*time.Minute)
+
+	document := discoverKeycloak(t, oauthAuthCodeNamespace)
+	if document.AuthorizationEndpoint == "" {
+		t.Fatalf("Keycloak discovery did not advertise an authorization endpoint")
+	}
+	importCertificateAuthority(t, oauthAuthCodeNamespace, infrastructure.Cluster.Name)
+
+	// Configure the Authorization Code external security and OAuth App Server.
+	externalSecurityPayload, err := mlmanage.BuildOAuthExternalSecurityPayload(authCodeExternalSecurityConfig(document, redirectURI))
+	if err != nil {
+		t.Fatalf("Build Authorization Code external-security payload: %v", err)
+	}
+	postManagementJSON(t, oauthAuthCodeNamespace, infrastructure.Cluster.Name, "/manage/v2/external-security", externalSecurityPayload)
+	postManagementJSON(t, oauthAuthCodeNamespace, infrastructure.Cluster.Name, "/manage/v2/servers?group-id=Default&server-type=http", mlmanage.BuildOAuthAppServerPayload(authCodeAppServerConfig()))
+
+	// Grant the disposable Keycloak identity a mapped MarkLogic role so a
+	// completed handshake yields an authorized 200 rather than only a 403.
+	assignExternalNameToAdmin(t, oauthAuthCodeNamespace, infrastructure.Cluster.Name, keycloak.TestUsername)
+
+	haproxyBase := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", haproxyServiceName, oauthAuthCodeNamespace, oauthAppServerPort)
+	node0Base := fmt.Sprintf("https://%s-0.%s.%s.svc.cluster.local:%d", infrastructure.Cluster.Name, infrastructure.Cluster.Name, oauthAuthCodeNamespace, oauthAppServerPort)
+	node1Base := fmt.Sprintf("https://%s-1.%s.%s.svc.cluster.local:%d", infrastructure.Cluster.Name, infrastructure.Cluster.Name, oauthAuthCodeNamespace, oauthAppServerPort)
+
+	// Wait for HAProxy's OAuth backend to pass its periodic health check before
+	// exercising the flow; the backend briefly reports 503 <NOSRV> right after the
+	// OAuth App Server is created, which would otherwise race the assertions.
+	waitForOAuthAppServerThroughHAProxy(t, oauthAuthCodeNamespace, haproxyBase, 2*time.Minute)
+
+	// TC1: the OAuth App Server must redirect to Keycloak and set SessionID
+	// before authentication, when reached through the HAProxy load balancer.
+	t.Run("TC1_SessionID_before_authentication", func(t *testing.T) {
+		result := runAuthCodeFlow(t, oauthAuthCodeNamespace, authCodeFlowConfig{
+			StartURL:     haproxyBase + "/",
+			CallbackBase: haproxyBase,
+			CarrySession: true,
+		})
+		if !strings.Contains(result["STEP1_STATUS"], "303") && !strings.Contains(result["STEP1_STATUS"], "302") {
+			t.Fatalf("expected a redirect (302/303) from the OAuth App Server, got %q\n%s", result["STEP1_STATUS"], result["_raw"])
+		}
+		if result["STEP1_SESSIONID"] == "" {
+			t.Fatalf("expected a SessionID cookie before authentication\n%s", result["_raw"])
+		}
+		if !strings.Contains(result["STEP1_LOCATION"], "code_challenge") || !strings.Contains(result["STEP1_LOCATION"], "response_type=code") {
+			t.Fatalf("expected an Authorization Code (PKCE) redirect to the IdP, got %q", result["STEP1_LOCATION"])
+		}
+	})
+
+	// TC2: with HAProxy SessionID affinity the callback returns to the initiating
+	// node and the Authorization Code flow completes successfully.
+	t.Run("TC2_affinity_completes_flow", func(t *testing.T) {
+		result := runAuthCodeFlow(t, oauthAuthCodeNamespace, authCodeFlowConfig{
+			StartURL:     haproxyBase + "/",
+			CallbackBase: haproxyBase,
+			CarrySession: true,
+		})
+		assertHandshakeCompleted(t, result)
+	})
+
+	// TC3: a callback delivered to a different node than the one that started the
+	// flow fails, because the PKCE verifier and state are node-local.
+	t.Run("TC3_cross_node_callback_fails", func(t *testing.T) {
+		result := runAuthCodeFlow(t, oauthAuthCodeNamespace, authCodeFlowConfig{
+			StartURL:     node0Base + "/",
+			CallbackBase: node1Base,
+			CarrySession: false,
+		})
+		assertHandshakeRejected(t, result)
+	})
+
+	if retainNamespaceFromEnvironment() {
+		t.Logf("Authorization Code infrastructure retained in namespace %s", oauthAuthCodeNamespace)
+	}
+}
+
+type authCodeFlowConfig struct {
+	StartURL     string
+	CallbackBase string
+	CarrySession bool
+}
+
+// runAuthCodeFlow drives a complete browser-style Authorization Code + PKCE login
+// through the OAuth App Server and Keycloak from inside the in-cluster curl client,
+// returning the parsed key=value markers the script emits.
+// waitForOAuthAppServerThroughHAProxy blocks until the HAProxy OAuth backend has a
+// healthy server. HAProxy's server health check runs periodically, so for a short
+// window after the OAuth App Server is created the 8013 backend reports 503 with
+// <NOSRV>; running the session-affinity cases before then would race the load
+// balancer rather than the flow.
+func waitForOAuthAppServerThroughHAProxy(t *testing.T, namespace, baseURL string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastStatus string
+	for {
+		lastStatus = strings.TrimSpace(testutil.ExecuteInPod(
+			t, namespace, oauthclient.DefaultName, "curl",
+			"curl", "--silent", "--output", "/dev/null", "--write-out", "%{http_code}",
+			"--head", baseURL+"/",
+		))
+		if lastStatus != "503" && lastStatus != "000" {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("HAProxy OAuth backend %s did not become healthy within %s (last status %q)", baseURL, timeout, lastStatus)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+func runAuthCodeFlow(t *testing.T, namespace string, config authCodeFlowConfig) map[string]string {
+	t.Helper()
+	carry := "no"
+	if config.CarrySession {
+		carry = "yes"
+	}
+	output := testutil.ExecuteInPod(
+		t,
+		namespace,
+		oauthclient.DefaultName,
+		"curl",
+		"sh", "-c", authCodeFlowScript, "authcode-flow",
+		config.StartURL,
+		config.CallbackBase,
+		keycloak.TestUsername,
+		keycloak.TestUserPassword,
+		carry,
+	)
+	result := parseMarkers(output)
+	result["_raw"] = output
+	t.Logf("Authorization Code flow markers:\n%s", output)
+	return result
+}
+
+func assertHandshakeCompleted(t *testing.T, result map[string]string) {
+	t.Helper()
+	if result["RESULT"] != "DONE" {
+		t.Fatalf("Authorization Code flow did not reach the callback: %s\n%s", result["RESULT"], result["_raw"])
+	}
+	status := result["STEP4_STATUS"]
+	if strings.Contains(status, "401") || strings.Contains(status, "400") || strings.Contains(status, "500") {
+		t.Fatalf("callback on the initiating node should complete, got %q\n%s", status, result["_raw"])
+	}
+	if strings.Contains(result["STEP4_LOCATION"], "/protocol/openid-connect/auth") {
+		t.Fatalf("callback should not restart the OAuth flow when affinity holds\n%s", result["_raw"])
+	}
+}
+
+func assertHandshakeRejected(t *testing.T, result map[string]string) {
+	t.Helper()
+	if result["RESULT"] != "DONE" {
+		t.Fatalf("cross-node negative case did not reach the callback: %s\n%s", result["RESULT"], result["_raw"])
+	}
+	status := result["STEP4_STATUS"]
+	restarted := strings.Contains(result["STEP4_LOCATION"], "/protocol/openid-connect/auth")
+	rejected := strings.Contains(status, "401") || strings.Contains(status, "400") || strings.Contains(status, "403") || strings.Contains(status, "500") || restarted
+	if !rejected {
+		t.Fatalf("cross-node callback should fail without the initiating node's OAuth state, got %q\n%s", status, result["_raw"])
+	}
+}
+
+func discoverKeycloak(t *testing.T, namespace string) openIDConfiguration {
+	t.Helper()
+	discovery := testutil.ExecuteInPod(
+		t, namespace, oauthclient.DefaultName, "curl",
+		"curl", "--fail", "--silent", "--show-error", keycloakDiscoveryURL(namespace),
+	)
+	document, err := parseOpenIDConfiguration([]byte(discovery))
+	if err != nil {
+		t.Fatalf("Parse Keycloak OpenID discovery document: %v\n%s", err, discovery)
+	}
+	if document.Issuer != keycloakIssuerURL(namespace) {
+		t.Fatalf("Keycloak discovery issuer = %q, want %q", document.Issuer, keycloakIssuerURL(namespace))
+	}
+	return document
+}
+
+func importCertificateAuthority(t *testing.T, namespace, clusterName string) {
+	t.Helper()
+	testutil.ExecuteInPod(
+		t, namespace, oauthclient.DefaultName, "curl",
+		"curl", "--fail", "--silent", "--show-error", "--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "POST", "--header", "Content-Type: text/plain",
+		"--data-binary", "@"+oauthclient.CAPath,
+		marklogicManagementURL(clusterName, namespace)+"/manage/v2/certificate-authorities",
+	)
+}
+
+func postManagementJSON(t *testing.T, namespace, clusterName, path string, payload any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal management payload for %s: %v", path, err)
+	}
+	testutil.ExecuteInPod(
+		t, namespace, oauthclient.DefaultName, "curl",
+		"curl", "--fail", "--silent", "--show-error", "--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "POST", "--header", "Accept: application/json", "--header", "Content-Type: application/json",
+		"--data-binary", string(body),
+		marklogicManagementURL(clusterName, namespace)+path,
+	)
+}
+
+// assignExternalNameToAdmin maps the Keycloak identity to the built-in admin role
+// so a completed Authorization Code handshake is authorized (Section 2.4 of the spec).
+func assignExternalNameToAdmin(t *testing.T, namespace, clusterName, externalName string) {
+	t.Helper()
+	payload := map[string]any{"external-name": []string{externalName}}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal admin role external-name payload: %v", err)
+	}
+	testutil.ExecuteInPod(
+		t, namespace, oauthclient.DefaultName, "curl",
+		"curl", "--fail", "--silent", "--show-error", "--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "PUT", "--header", "Content-Type: application/json",
+		"--data-binary", string(body),
+		marklogicManagementURL(clusterName, namespace)+"/manage/v2/roles/admin/properties",
+	)
+}
+
+func parseMarkers(output string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimRight(line, "\r")
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		if _, exists := result[key]; !exists {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+// authCodeFlowScript performs a full Authorization Code + PKCE + form_post login
+// from the in-cluster curl client. MarkLogic generates the PKCE verifier and
+// state, so the script only follows MarkLogic's redirect, submits the Keycloak
+// login form, and posts the callback. Positional args:
+//
+//	$1 START_URL     initial OAuth App Server URL
+//	$2 CALLBACK_BASE scheme://host[:port] to send the callback to
+//	$3 USERNAME
+//	$4 PASSWORD
+//	$5 CARRY_SESSION "yes" to send the initiating SessionID cookie on the callback
+const authCodeFlowScript = `
+START_URL="$1"; CALLBACK_BASE="$2"; USER="$3"; PASS="$4"; CARRY="$5"
+JAR=$(mktemp); KCJAR=$(mktemp)
+
+H1=$(curl -sk -c "$JAR" -D - -o /dev/null "$START_URL")
+echo "STEP1_STATUS=$(printf '%s' "$H1" | head -1 | tr -d '\r')"
+LOC=$(printf '%s' "$H1" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2; exit}')
+SID=$(awk '$6=="SessionID"{v=$7} END{print v}' "$JAR")
+echo "STEP1_SESSIONID=$SID"
+echo "STEP1_LOCATION=$LOC"
+if [ -z "$LOC" ]; then echo "RESULT=NO_REDIRECT"; exit 0; fi
+
+LOGIN=$(curl -sk -c "$KCJAR" -b "$KCJAR" "$LOC")
+ACTION=$(printf '%s' "$LOGIN" | grep -io 'action="[^"]*login-actions/authenticate[^"]*"' | head -1 | sed -e 's/^[aA][cC][tT][iI][oO][nN]="//' -e 's/"$//' -e 's/&amp;/\&/g')
+if [ -z "$ACTION" ]; then ACTION=$(printf '%s' "$LOGIN" | grep -io 'action="[^"]*"' | head -1 | sed -e 's/^[aA][cC][tT][iI][oO][nN]="//' -e 's/"$//' -e 's/&amp;/\&/g'); fi
+echo "STEP2_ACTION_PRESENT=$([ -n "$ACTION" ] && echo yes || echo no)"
+if [ -z "$ACTION" ]; then echo "RESULT=NO_LOGIN_FORM"; printf '%s' "$LOGIN" | head -40; exit 0; fi
+
+# Keycloak's form_post response emits UPPERCASE HTML (<INPUT NAME="code" VALUE="..."/>)
+# while the login page is lowercase, so all attribute parsing must be case-insensitive.
+POST=$(curl -sk -c "$KCJAR" -b "$KCJAR" --data-urlencode "username=$USER" --data-urlencode "password=$PASS" --data-urlencode "credentialId=" "$ACTION")
+CODE=$(printf '%s' "$POST" | grep -io 'name="code"[^>]*' | head -1 | grep -io 'value="[^"]*"' | head -1 | sed -e 's/^[vV][aA][lL][uU][eE]="//' -e 's/"$//')
+STATE=$(printf '%s' "$POST" | grep -io 'name="state"[^>]*' | head -1 | grep -io 'value="[^"]*"' | head -1 | sed -e 's/^[vV][aA][lL][uU][eE]="//' -e 's/"$//')
+CBACT=$(printf '%s' "$POST" | grep -io 'action="[^"]*"' | head -1 | sed -e 's/^[aA][cC][tT][iI][oO][nN]="//' -e 's/"$//' -e 's/&amp;/\&/g')
+echo "STEP3_CODE_PRESENT=$([ -n "$CODE" ] && echo yes || echo no)"
+echo "STEP3_STATE_PRESENT=$([ -n "$STATE" ] && echo yes || echo no)"
+if [ -z "$CODE" ] || [ -z "$STATE" ]; then echo "RESULT=NO_CODE"; printf '%s' "$POST" | head -60; exit 0; fi
+
+PATHQ=$(printf '%s' "$CBACT" | sed -e 's#^https\{0,1\}://[^/]*##')
+if [ -z "$PATHQ" ]; then PATHQ="/oauth/callback"; fi
+CBURL="${CALLBACK_BASE}${PATHQ}"
+echo "CALLBACK_URL=$CBURL"
+
+B4=$(mktemp)
+if [ "$CARRY" = "yes" ] && [ -n "$SID" ]; then
+  H4=$(curl -sk -b "SessionID=$SID" -D - -o "$B4" --data-urlencode "code=$CODE" --data-urlencode "state=$STATE" "$CBURL")
+else
+  H4=$(curl -sk -D - -o "$B4" --data-urlencode "code=$CODE" --data-urlencode "state=$STATE" "$CBURL")
+fi
+echo "STEP4_STATUS=$(printf '%s' "$H4" | head -1 | tr -d '\r')"
+echo "STEP4_LOCATION=$(printf '%s' "$H4" | tr -d '\r' | awk 'tolower($1)=="location:"{print $2; exit}')"
+printf '%s' "$H4" | tr -d '\r' | grep -iE '^(www-authenticate|set-cookie):' | head -5
+echo "STEP4_BODY_BEGIN"
+head -40 "$B4"
+echo "STEP4_BODY_END"
+echo "RESULT=DONE"
+`

--- a/test/integration/marklogic-server/oauth/oauth_load_balancer_affinity_test.go
+++ b/test/integration/marklogic-server/oauth/oauth_load_balancer_affinity_test.go
@@ -171,5 +171,5 @@ func TestOAuthResourceServerInfrastructure(t *testing.T) {
 		t.Fatalf("OAuth App Server external security = %#v", appServer["external-security"])
 	}
 
-	t.Skip("OAuth external security and a direct OAuth App Server were created; HAProxy routing and bearer-token assertions are not implemented yet; see docs/test/oauth-load-balancer-affinity-test.md")
+	t.Log("OAuth external security and a direct OAuth App Server were created; HAProxy routing and bearer-token assertions are not implemented yet; see docs/test/oauth-load-balancer-affinity-test.md")
 }

--- a/test/integration/marklogic-server/oauth/oauth_load_balancer_affinity_test.go
+++ b/test/integration/marklogic-server/oauth/oauth_load_balancer_affinity_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauth
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/marklogic/marklogic-operator-kubernetes/pkg/mlmanage"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/keycloak"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/oauthclient"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/testutil"
+)
+
+const oauthSessionAffinityNamespace = "ml-oauth-session-affinity"
+
+func TestOAuthResourceServerInfrastructure(t *testing.T) {
+	if !resourceServerTestEnabledFromEnvironment() {
+		t.Skipf("set %s=true to run OAuth resource-server infrastructure setup", oauthResourceServerTestEnvironment)
+	}
+	redirectURI, _ := redirectURIFromEnvironment()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			testutil.CollectKubernetesDiagnostics(t, oauthSessionAffinityNamespace)
+		}
+		if retainNamespaceFromEnvironment() {
+			t.Logf("Retaining namespace %s because %s=true", oauthSessionAffinityNamespace, oauthRetainNamespaceEnvironment)
+			return
+		}
+		testutil.DeleteNamespace(t, oauthSessionAffinityNamespace)
+	})
+
+	infrastructure := DeployInfrastructure(t, InfrastructureConfig{
+		Namespace:   oauthSessionAffinityNamespace,
+		RedirectURI: redirectURI,
+		Image:       marklogicImageFromEnvironment(),
+	})
+	testutil.WaitForStatefulSetReady(t, oauthSessionAffinityNamespace, infrastructure.Cluster.Name, 15*time.Minute)
+	testutil.WaitForDeploymentAvailable(t, oauthSessionAffinityNamespace, haproxyServiceName, 5*time.Minute)
+	testutil.WaitForDeploymentAvailable(t, oauthSessionAffinityNamespace, keycloak.Name, 5*time.Minute)
+	testutil.WaitForPodReady(t, oauthSessionAffinityNamespace, oauthclient.DefaultName, 2*time.Minute)
+	discovery := testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		keycloakDiscoveryURL(oauthSessionAffinityNamespace),
+	)
+	document, err := parseOpenIDConfiguration([]byte(discovery))
+	if err != nil {
+		t.Fatalf("Parse Keycloak OpenID discovery document: %v\n%s", err, discovery)
+	}
+	if document.Issuer != keycloakIssuerURL(oauthSessionAffinityNamespace) {
+		t.Fatalf("Keycloak discovery issuer = %q, want %q", document.Issuer, keycloakIssuerURL(oauthSessionAffinityNamespace))
+	}
+	tokenResponse := testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		"--request", "POST",
+		"--data-urlencode", "grant_type=password",
+		"--data-urlencode", "client_id="+keycloak.ClientID,
+		"--data-urlencode", "username="+keycloak.TestUsername,
+		"--data-urlencode", "password="+keycloak.TestUserPassword,
+		document.TokenEndpoint,
+	)
+	var token struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal([]byte(tokenResponse), &token); err != nil {
+		t.Fatalf("Decode Keycloak access token response: %v\n%s", err, tokenResponse)
+	}
+	if token.AccessToken == "" {
+		t.Fatalf("Keycloak access token response did not contain an access token: %s", tokenResponse)
+	}
+	testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		"--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "POST",
+		"--header", "Content-Type: text/plain",
+		"--data-binary", "@"+oauthclient.CAPath,
+		marklogicManagementURL(infrastructure.Cluster.Name, oauthSessionAffinityNamespace)+"/manage/v2/certificate-authorities",
+	)
+	externalSecurityPayload, err := mlmanage.BuildOAuthExternalSecurityPayload(resourceServerExternalSecurityConfig(document))
+	if err != nil {
+		t.Fatalf("Build OAuth external-security payload: %v", err)
+	}
+	payloadBytes, err := json.Marshal(externalSecurityPayload)
+	if err != nil {
+		t.Fatalf("Marshal OAuth external-security payload: %v", err)
+	}
+	testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		"--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "POST",
+		"--header", "Accept: application/json",
+		"--header", "Content-Type: application/json",
+		"--data-binary", string(payloadBytes),
+		marklogicManagementURL(infrastructure.Cluster.Name, oauthSessionAffinityNamespace)+"/manage/v2/external-security",
+	)
+	appServerPayload, err := json.Marshal(mlmanage.BuildOAuthAppServerPayload(resourceServerAppServerConfig()))
+	if err != nil {
+		t.Fatalf("Marshal OAuth App Server payload: %v", err)
+	}
+	testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		"--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		"--request", "POST",
+		"--header", "Accept: application/json",
+		"--header", "Content-Type: application/json",
+		"--data-binary", string(appServerPayload),
+		marklogicManagementURL(infrastructure.Cluster.Name, oauthSessionAffinityNamespace)+"/manage/v2/servers?group-id=Default&server-type=http",
+	)
+	appServerProperties := testutil.ExecuteInPod(
+		t,
+		oauthSessionAffinityNamespace,
+		oauthclient.DefaultName,
+		"curl",
+		"curl",
+		"--fail",
+		"--silent",
+		"--show-error",
+		"--digest",
+		"--user", marklogicAdminUsername+":"+marklogicAdminPassword,
+		marklogicManagementURL(infrastructure.Cluster.Name, oauthSessionAffinityNamespace)+"/manage/v2/servers/"+oauthAppServerName+"/properties?group-id=Default&format=json",
+	)
+	var appServer map[string]any
+	if err := json.Unmarshal([]byte(appServerProperties), &appServer); err != nil {
+		t.Fatalf("Decode OAuth App Server properties: %v\n%s", err, appServerProperties)
+	}
+	if appServer["port"] != float64(oauthAppServerPort) || appServer["authentication"] != "oauth" || appServer["internal-security"] != false {
+		t.Fatalf("OAuth App Server properties = %#v", appServer)
+	}
+	externalSecurity, ok := appServer["external-security"].([]any)
+	if !ok || len(externalSecurity) != 1 || externalSecurity[0] != oauthExternalSecurityName {
+		t.Fatalf("OAuth App Server external security = %#v", appServer["external-security"])
+	}
+
+	t.Skip("OAuth external security and a direct OAuth App Server were created; HAProxy routing and bearer-token assertions are not implemented yet; see docs/test/oauth-load-balancer-affinity-test.md")
+}

--- a/test/integration/marklogic-server/oauth/oauth_setup.go
+++ b/test/integration/marklogic-server/oauth/oauth_setup.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"github.com/marklogic/marklogic-operator-kubernetes/pkg/mlmanage"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/keycloak"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/marklogiccluster"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/oauthclient"
+	tlsfixture "github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/fixtures/tls"
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/testutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	oauthCASecretName                  = "oauth-test-ca"
+	marklogicCertificate0              = "marklogic-0-tls"
+	marklogicCertificate1              = "marklogic-1-tls"
+	keycloakCertificate                = "keycloak-tls"
+	haproxyCertificate                 = "marklogic-haproxy-tls"
+	haproxyCertFileName                = "tls.pem"
+	marklogicAdminUsername             = "admin"
+	marklogicAdminPassword             = "Admin@8001"
+	haproxyServiceName                 = "marklogic-haproxy"
+	oauthRedirectURIEnvironment        = "MARKLOGIC_OAUTH_REDIRECT_URI"
+	oauthResourceServerTestEnvironment = "MARKLOGIC_OAUTH_RESOURCE_SERVER"
+	oauthAuthCodeTestEnvironment       = "MARKLOGIC_OAUTH_AUTHORIZATION_CODE"
+	oauthRetainNamespaceEnvironment    = "MARKLOGIC_OAUTH_RETAIN_NAMESPACE"
+	marklogicImageEnvironment          = "MARKLOGIC_IMAGE"
+	oauthExternalSecurityName          = "keycloak-resource-server"
+	oauthAppServerName                 = "oauth-resource-server"
+	oauthAppServerPort                 = 8013
+	authCodeExternalSecurityName       = "keycloak-authorization-code"
+	authCodeAppServerName              = "oauth-authorization-code"
+	authCodeCertificateTemplate        = "oauthAuthCodeTemplate"
+	authCodeCallbackPath               = "/oauth/callback"
+)
+
+type Infrastructure struct {
+	RedirectURI string
+	TLS         tlsfixture.ClusterResources
+	Keycloak    keycloak.Resources
+	Cluster     *marklogicv1.MarklogicCluster
+	Client      *corev1.Pod
+}
+
+type InfrastructureConfig struct {
+	Namespace   string
+	RedirectURI string
+	Image       string
+}
+
+type openIDConfiguration struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+func (infrastructure Infrastructure) Objects() []runtime.Object {
+	objects := make([]runtime.Object, 0, 6+len(infrastructure.TLS.TLSSecrets))
+	objects = append(objects, infrastructure.TLS.CASecret)
+	for _, secret := range infrastructure.TLS.TLSSecrets {
+		objects = append(objects, secret)
+	}
+	objects = append(objects,
+		infrastructure.Keycloak.AdminSecret,
+		infrastructure.Keycloak.RealmConfigMap,
+		infrastructure.Keycloak.Deployment,
+		infrastructure.Keycloak.Service,
+	)
+	objects = append(objects, infrastructure.Cluster, infrastructure.Client)
+	return objects
+}
+
+func DeployInfrastructure(t *testing.T, config InfrastructureConfig) Infrastructure {
+	t.Helper()
+	infrastructure, err := BuildInfrastructure(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.EnsureNamespace(t, config.Namespace)
+	testutil.ApplyObjects(t, infrastructure.Objects()...)
+	return infrastructure
+}
+
+func BuildInfrastructure(config InfrastructureConfig) (Infrastructure, error) {
+	if config.Namespace == "" {
+		return Infrastructure{}, fmt.Errorf("namespace is required")
+	}
+	redirectURI := strings.TrimSpace(config.RedirectURI)
+	clusterName := marklogiccluster.DefaultName
+	marklogic0DNSNames := marklogicServerDNSNames(clusterName, config.Namespace, 0)
+	marklogic1DNSNames := marklogicServerDNSNames(clusterName, config.Namespace, 1)
+	if redirectURI != "" {
+		callbackHostname, err := callbackHostname(redirectURI)
+		if err != nil {
+			return Infrastructure{}, err
+		}
+		marklogic0DNSNames = append(marklogic0DNSNames, callbackHostname)
+		marklogic1DNSNames = append(marklogic1DNSNames, callbackHostname)
+	}
+
+	tlsResources, err := tlsfixture.BuildClusterResources(tlsfixture.ClusterConfig{
+		Namespace:    config.Namespace,
+		CASecretName: oauthCASecretName,
+		Servers: []tlsfixture.ServerConfig{
+			{TLSSecretName: marklogicCertificate0, DNSNames: marklogic0DNSNames},
+			{TLSSecretName: marklogicCertificate1, DNSNames: marklogic1DNSNames},
+			{TLSSecretName: keycloakCertificate, DNSNames: keycloakDNSNames(config.Namespace)},
+			{TLSSecretName: haproxyCertificate, DNSNames: haproxyDNSNames(config.Namespace), PEMFileName: haproxyCertFileName},
+		},
+	})
+	if err != nil {
+		return Infrastructure{}, err
+	}
+	keycloakResources, err := keycloak.BuildResources(keycloak.Config{
+		Namespace:     config.Namespace,
+		RedirectURI:   redirectURI,
+		IssuerURL:     keycloakBaseURL(config.Namespace),
+		TLSSecretName: keycloakCertificate,
+	})
+	if err != nil {
+		return Infrastructure{}, err
+	}
+	cluster, err := marklogiccluster.Build(marklogiccluster.Config{
+		Namespace:              config.Namespace,
+		Name:                   clusterName,
+		Image:                  config.Image,
+		AdminUsername:          marklogicAdminUsername,
+		AdminPassword:          marklogicAdminPassword,
+		CASecretName:           tlsResources.CASecret.Name,
+		CertificateSecretNames: []string{marklogicCertificate0, marklogicCertificate1},
+	})
+	if err != nil {
+		return Infrastructure{}, err
+	}
+	cluster.Spec.HAProxy.AppServers = append(cluster.Spec.HAProxy.AppServers, marklogicv1.AppServers{
+		Name: oauthAppServerName,
+		Port: oauthAppServerPort,
+	})
+	// Terminate TLS at the HAProxy frontend so it can run in HTTP mode and apply
+	// SessionID cookie affinity while still re-encrypting to the HTTPS MarkLogic
+	// App Servers. Without frontend TLS the OAuth App Server port would receive a
+	// raw TLS handshake on a plaintext HTTP listener and reject it as a bad request.
+	cluster.Spec.HAProxy.Tls = &marklogicv1.TlsForHAProxy{
+		Enabled:      true,
+		SecretName:   haproxyCertificate,
+		CertFileName: haproxyCertFileName,
+	}
+	client, err := oauthclient.Build(oauthclient.Config{Namespace: config.Namespace, CASecretName: tlsResources.CASecret.Name})
+	if err != nil {
+		return Infrastructure{}, err
+	}
+	return Infrastructure{
+		RedirectURI: redirectURI,
+		TLS:         tlsResources,
+		Keycloak:    keycloakResources,
+		Cluster:     cluster,
+		Client:      client,
+	}, nil
+}
+
+func callbackHostname(redirectURI string) (string, error) {
+	parsed, err := url.ParseRequestURI(redirectURI)
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil {
+		return "", fmt.Errorf("redirect URI must be an HTTPS URL with a hostname")
+	}
+	if net.ParseIP(parsed.Hostname()) != nil {
+		return "", fmt.Errorf("redirect URI hostname must be a DNS name")
+	}
+	return parsed.Hostname(), nil
+}
+
+func redirectURIFromEnvironment() (string, bool) {
+	redirectURI := strings.TrimSpace(os.Getenv(oauthRedirectURIEnvironment))
+	return redirectURI, redirectURI != ""
+}
+
+func resourceServerTestEnabledFromEnvironment() bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(oauthResourceServerTestEnvironment)))
+	return err == nil && enabled
+}
+
+func authCodeTestEnabledFromEnvironment() bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(oauthAuthCodeTestEnvironment)))
+	return err == nil && enabled
+}
+
+func marklogicImageFromEnvironment() string {
+	return strings.TrimSpace(os.Getenv(marklogicImageEnvironment))
+}
+
+func retainNamespaceFromEnvironment() bool {
+	retain, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(oauthRetainNamespaceEnvironment)))
+	return err == nil && retain
+}
+
+func parseOpenIDConfiguration(body []byte) (openIDConfiguration, error) {
+	var configuration openIDConfiguration
+	if err := json.Unmarshal(body, &configuration); err != nil {
+		return openIDConfiguration{}, fmt.Errorf("decode OpenID discovery document: %w", err)
+	}
+	for field, value := range map[string]string{
+		"issuer":                 configuration.Issuer,
+		"authorization endpoint": configuration.AuthorizationEndpoint,
+		"token endpoint":         configuration.TokenEndpoint,
+		"JWKS URI":               configuration.JWKSURI,
+	} {
+		parsed, err := url.ParseRequestURI(value)
+		if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" {
+			return openIDConfiguration{}, fmt.Errorf("OpenID discovery %s must be an HTTPS URL", field)
+		}
+	}
+	return configuration, nil
+}
+
+func resourceServerExternalSecurityConfig(document openIDConfiguration) mlmanage.OAuthExternalSecurityConfig {
+	return mlmanage.OAuthExternalSecurityConfig{
+		Name:              oauthExternalSecurityName,
+		Authentication:    "oauth",
+		Authorization:     "internal",
+		CacheTimeout:      300,
+		FlowType:          "Resource server",
+		Vendor:            "Other",
+		ClientID:          keycloak.ClientID,
+		TokenType:         "JSON Web Tokens",
+		UsernameAttribute: "preferred_username",
+		RoleAttribute:     "roles",
+		JWTIssuerURI:      document.Issuer,
+		JWTAlgorithm:      "RS256",
+		JWKSURI:           document.JWKSURI,
+	}
+}
+
+func resourceServerAppServerConfig() mlmanage.OAuthAppServerConfig {
+	return mlmanage.OAuthAppServerConfig{
+		Name:                   oauthAppServerName,
+		Group:                  "Default",
+		Root:                   "/",
+		Port:                   oauthAppServerPort,
+		ContentDatabase:        "Documents",
+		ExternalSecurityName:   oauthExternalSecurityName,
+		TLSCertificateTemplate: "defaultTemplate",
+	}
+}
+
+func authCodeExternalSecurityConfig(document openIDConfiguration, redirectURI string) mlmanage.OAuthExternalSecurityConfig {
+	return mlmanage.OAuthExternalSecurityConfig{
+		Name:                   authCodeExternalSecurityName,
+		Authentication:         "oauth",
+		Authorization:          "internal",
+		CacheTimeout:           300,
+		FlowType:               "Authorization code",
+		Vendor:                 "Other",
+		ClientID:               keycloak.AuthCodeClientID,
+		ClientSecret:           keycloak.AuthCodeClientSecret,
+		RedirectURI:            redirectURI,
+		AuthorizationServerURI: document.AuthorizationEndpoint,
+		TokenServerURI:         document.TokenEndpoint,
+		TokenType:              "JSON Web Tokens",
+		UsernameAttribute:      "preferred_username",
+		RoleAttribute:          "roles",
+		JWTIssuerURI:           document.Issuer,
+		JWTAlgorithm:           "RS256",
+		JWKSURI:                document.JWKSURI,
+	}
+}
+
+func authCodeAppServerConfig() mlmanage.OAuthAppServerConfig {
+	return mlmanage.OAuthAppServerConfig{
+		Name:                   authCodeAppServerName,
+		Group:                  "Default",
+		Root:                   "/",
+		Port:                   oauthAppServerPort,
+		ContentDatabase:        "Documents",
+		ExternalSecurityName:   authCodeExternalSecurityName,
+		TLSCertificateTemplate: "defaultTemplate",
+	}
+}
+
+// authCodeRedirectURI returns the HTTPS callback URL, routed through the operator
+// HAProxy service on the OAuth App Server port, that MarkLogic advertises to the
+// authorization server and that Keycloak registers as a valid redirect URI.
+func authCodeRedirectURI(namespace string) string {
+	return fmt.Sprintf("https://%s.%s.svc.cluster.local:%d%s", haproxyServiceName, namespace, oauthAppServerPort, authCodeCallbackPath)
+}
+
+func marklogicServerDNSNames(clusterName, namespace string, ordinal int) []string {
+	podDNSName := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local", clusterName, ordinal, clusterName, namespace)
+	return []string{
+		podDNSName,
+		haproxyServiceName,
+		fmt.Sprintf("%s.%s", haproxyServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc", haproxyServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", haproxyServiceName, namespace),
+	}
+}
+
+func marklogicManagementURL(clusterName, namespace string) string {
+	return "https://" + marklogicServerDNSNames(clusterName, namespace, 0)[0] + ":8002"
+}
+
+func keycloakIssuerURL(namespace string) string {
+	return keycloakBaseURL(namespace) + "/realms/" + keycloak.Realm
+}
+
+func keycloakBaseURL(namespace string) string {
+	return "https://" + keycloakDNSNames(namespace)[3] + ":8443"
+}
+
+func keycloakDiscoveryURL(namespace string) string {
+	return keycloakIssuerURL(namespace) + "/.well-known/openid-configuration"
+}
+
+func haproxyDNSNames(namespace string) []string {
+	return []string{
+		haproxyServiceName,
+		fmt.Sprintf("%s.%s", haproxyServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc", haproxyServiceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", haproxyServiceName, namespace),
+	}
+}
+
+func keycloakDNSNames(namespace string) []string {
+	return []string{
+		keycloak.Name,
+		fmt.Sprintf("%s.%s", keycloak.Name, namespace),
+		fmt.Sprintf("%s.%s.svc", keycloak.Name, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", keycloak.Name, namespace),
+	}
+}

--- a/test/integration/marklogic-server/oauth/oauth_setup_test.go
+++ b/test/integration/marklogic-server/oauth/oauth_setup_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauth
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestBuildInfrastructureCreatesTLSHAProxyTopology(t *testing.T) {
+	callbackURI := "https://oauth.example.test/callback"
+	resources, err := BuildInfrastructure(InfrastructureConfig{
+		Namespace:   oauthSessionAffinityNamespace,
+		RedirectURI: callbackURI,
+	})
+	if err != nil {
+		t.Fatalf("BuildInfrastructure returned an error: %v", err)
+	}
+	if resources.Cluster.Namespace != oauthSessionAffinityNamespace {
+		t.Fatalf("cluster namespace = %q, want %q", resources.Cluster.Namespace, oauthSessionAffinityNamespace)
+	}
+	if appServers := resources.Cluster.Spec.HAProxy.AppServers; len(appServers) != 3 || appServers[2].Name != oauthAppServerName || appServers[2].Port != oauthAppServerPort {
+		t.Fatalf("HAProxy App Servers = %#v, want OAuth App Server %q on port %d", appServers, oauthAppServerName, oauthAppServerPort)
+	}
+	if len(resources.TLS.TLSSecrets) != 4 {
+		t.Fatalf("TLS Secret count = %d, want 4", len(resources.TLS.TLSSecrets))
+	}
+	for index, secret := range resources.TLS.TLSSecrets[:2] {
+		certificateBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+		if certificateBlock == nil {
+			t.Fatalf("TLS Secret %d does not contain tls.crt", index)
+		}
+		certificate, err := x509.ParseCertificate(certificateBlock.Bytes)
+		if err != nil {
+			t.Fatalf("parse TLS certificate %d: %v", index, err)
+		}
+		for _, hostname := range []string{
+			marklogicServerDNSNames(marklogicClusterName(resources), oauthSessionAffinityNamespace, index)[0],
+			haproxyServiceName + "." + oauthSessionAffinityNamespace + ".svc.cluster.local",
+			"oauth.example.test",
+		} {
+			if err := certificate.VerifyHostname(hostname); err != nil {
+				t.Fatalf("TLS certificate %d does not trust %q: %v", index, hostname, err)
+			}
+		}
+	}
+	keycloakCertificate := decodeCertificate(t, resources.TLS.TLSSecrets[2])
+	if !containsString(keycloakCertificate.DNSNames, "keycloak."+oauthSessionAffinityNamespace+".svc.cluster.local") {
+		t.Fatalf("Keycloak certificate DNS names = %#v, want cluster-local service hostname", keycloakCertificate.DNSNames)
+	}
+	haproxySecret := resources.TLS.TLSSecrets[3]
+	if haproxySecret.Name != haproxyCertificate {
+		t.Fatalf("HAProxy TLS Secret name = %q, want %q", haproxySecret.Name, haproxyCertificate)
+	}
+	haproxyPEM, ok := haproxySecret.Data[haproxyCertFileName]
+	if !ok {
+		t.Fatalf("HAProxy TLS Secret is missing combined PEM key %q", haproxyCertFileName)
+	}
+	haproxyCertBlock, _ := pem.Decode(haproxyPEM)
+	if haproxyCertBlock == nil {
+		t.Fatalf("HAProxy TLS Secret PEM does not contain a certificate")
+	}
+	haproxyCert, err := x509.ParseCertificate(haproxyCertBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse HAProxy certificate: %v", err)
+	}
+	if err := haproxyCert.VerifyHostname(haproxyServiceName + "." + oauthSessionAffinityNamespace + ".svc.cluster.local"); err != nil {
+		t.Fatalf("HAProxy certificate does not trust the load balancer hostname: %v", err)
+	}
+	if tls := resources.Cluster.Spec.HAProxy.Tls; tls == nil || !tls.Enabled || tls.SecretName != haproxyCertificate || tls.CertFileName != haproxyCertFileName {
+		t.Fatalf("HAProxy TLS configuration = %#v, want frontend TLS termination enabled", resources.Cluster.Spec.HAProxy.Tls)
+	}
+	if resources.Client.Namespace != oauthSessionAffinityNamespace {
+		t.Fatalf("client namespace = %q, want %q", resources.Client.Namespace, oauthSessionAffinityNamespace)
+	}
+	if resources.Client.Spec.Volumes[0].Secret == nil || resources.Client.Spec.Volumes[0].Secret.SecretName != resources.TLS.CASecret.Name {
+		t.Fatalf("client CA Secret = %#v, want %q", resources.Client.Spec.Volumes[0].Secret, resources.TLS.CASecret.Name)
+	}
+	if resources.RedirectURI != callbackURI {
+		t.Fatalf("redirect URI = %q, want %q", resources.RedirectURI, callbackURI)
+	}
+	if realm := resources.Keycloak.RealmConfigMap.Data["realm-marklogic-oauth.json"]; !strings.Contains(realm, callbackURI) {
+		t.Fatalf("Keycloak realm does not contain redirect URI %q: %s", callbackURI, realm)
+	}
+	if !strings.Contains(resources.Keycloak.Deployment.Spec.Template.Spec.Containers[0].Args[len(resources.Keycloak.Deployment.Spec.Template.Spec.Containers[0].Args)-1], "keycloak."+oauthSessionAffinityNamespace+".svc.cluster.local:8443") {
+		t.Fatalf("Keycloak hostname argument = %#v, want cluster-local HTTPS issuer", resources.Keycloak.Deployment.Spec.Template.Spec.Containers[0].Args)
+	}
+}
+
+func TestBuildInfrastructureRequiresNamespace(t *testing.T) {
+	if _, err := BuildInfrastructure(InfrastructureConfig{RedirectURI: "https://oauth.example.test/callback"}); err == nil {
+		t.Fatal("BuildInfrastructure accepted an empty namespace")
+	}
+}
+
+func TestBuildInfrastructureRequiresHTTPSRedirectURI(t *testing.T) {
+	for _, redirectURI := range []string{"http://oauth.example.test/callback", "https:///callback"} {
+		t.Run(redirectURI, func(t *testing.T) {
+			if _, err := BuildInfrastructure(InfrastructureConfig{Namespace: oauthSessionAffinityNamespace, RedirectURI: redirectURI}); err == nil {
+				t.Fatalf("BuildInfrastructure accepted invalid redirect URI %q", redirectURI)
+			}
+		})
+	}
+}
+
+func TestBuildInfrastructureAllowsNoRedirectURI(t *testing.T) {
+	resources, err := BuildInfrastructure(InfrastructureConfig{Namespace: oauthSessionAffinityNamespace})
+	if err != nil {
+		t.Fatalf("BuildInfrastructure rejected resource-server configuration without a redirect URI: %v", err)
+	}
+	if resources.RedirectURI != "" {
+		t.Fatalf("redirect URI = %q, want empty", resources.RedirectURI)
+	}
+	if realm := resources.Keycloak.RealmConfigMap.Data["realm-marklogic-oauth.json"]; strings.Contains(realm, "redirectUris") {
+		t.Fatalf("resource-server realm client unexpectedly includes redirect URIs: %s", realm)
+	}
+}
+
+func TestRedirectURIFromEnvironment(t *testing.T) {
+	const expected = "https://oauth.example.test/callback"
+	t.Setenv(oauthRedirectURIEnvironment, expected)
+	if redirectURI, ok := redirectURIFromEnvironment(); !ok || redirectURI != expected {
+		t.Fatalf("redirectURIFromEnvironment() = (%q, %t), want (%q, true)", redirectURI, ok, expected)
+	}
+
+	t.Setenv(oauthRedirectURIEnvironment, "")
+	if redirectURI, ok := redirectURIFromEnvironment(); ok || redirectURI != "" {
+		t.Fatalf("redirectURIFromEnvironment() = (%q, %t), want (\"\", false)", redirectURI, ok)
+	}
+}
+
+func TestResourceServerTestEnabledFromEnvironment(t *testing.T) {
+	t.Setenv(oauthResourceServerTestEnvironment, "true")
+	if !resourceServerTestEnabledFromEnvironment() {
+		t.Fatal("resourceServerTestEnabledFromEnvironment() = false, want true")
+	}
+
+	t.Setenv(oauthResourceServerTestEnvironment, "false")
+	if resourceServerTestEnabledFromEnvironment() {
+		t.Fatal("resourceServerTestEnabledFromEnvironment() = true, want false")
+	}
+
+	t.Setenv(oauthResourceServerTestEnvironment, "not-a-bool")
+	if resourceServerTestEnabledFromEnvironment() {
+		t.Fatal("resourceServerTestEnabledFromEnvironment() = true for invalid value")
+	}
+}
+
+func TestRetainNamespaceFromEnvironment(t *testing.T) {
+	t.Setenv(oauthRetainNamespaceEnvironment, "true")
+	if !retainNamespaceFromEnvironment() {
+		t.Fatal("retainNamespaceFromEnvironment() = false, want true")
+	}
+
+	t.Setenv(oauthRetainNamespaceEnvironment, "false")
+	if retainNamespaceFromEnvironment() {
+		t.Fatal("retainNamespaceFromEnvironment() = true, want false")
+	}
+
+	t.Setenv(oauthRetainNamespaceEnvironment, "not-a-bool")
+	if retainNamespaceFromEnvironment() {
+		t.Fatal("retainNamespaceFromEnvironment() = true for invalid value")
+	}
+}
+
+func TestParseOpenIDConfiguration(t *testing.T) {
+	configuration, err := parseOpenIDConfiguration([]byte(`{
+		"issuer":"https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth",
+		"authorization_endpoint":"https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/protocol/openid-connect/auth",
+		"token_endpoint":"https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/protocol/openid-connect/token",
+		"jwks_uri":"https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/protocol/openid-connect/certs"
+	}`))
+	if err != nil {
+		t.Fatalf("parseOpenIDConfiguration returned an error: %v", err)
+	}
+	if configuration.TokenEndpoint != "https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/protocol/openid-connect/token" {
+		t.Fatalf("token endpoint = %q", configuration.TokenEndpoint)
+	}
+
+	if _, err := parseOpenIDConfiguration([]byte(`{"issuer":"http://keycloak.example.test","authorization_endpoint":"https://keycloak.example.test/auth","token_endpoint":"https://keycloak.example.test/token","jwks_uri":"https://keycloak.example.test/certs"}`)); err == nil {
+		t.Fatal("parseOpenIDConfiguration accepted an insecure issuer")
+	}
+}
+
+func TestResourceServerExternalSecurityConfigUsesDiscoveryEndpoints(t *testing.T) {
+	document := openIDConfiguration{
+		Issuer:  "https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth",
+		JWKSURI: "https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/protocol/openid-connect/certs",
+	}
+	config := resourceServerExternalSecurityConfig(document)
+	if config.FlowType != "Resource server" || config.TokenType != "JSON Web Tokens" {
+		t.Fatalf("resource-server configuration = %#v", config)
+	}
+	if config.Authorization != "internal" || config.Vendor != "Other" || config.CacheTimeout != 300 {
+		t.Fatalf("live-verified resource-server configuration = %#v", config)
+	}
+	if config.JWTIssuerURI != document.Issuer || config.JWKSURI != document.JWKSURI {
+		t.Fatalf("discovery URLs were not propagated: %#v", config)
+	}
+}
+
+func TestResourceServerAppServerConfigUsesDedicatedOAuthPort(t *testing.T) {
+	config := resourceServerAppServerConfig()
+	if config.Name != oauthAppServerName || config.Port != oauthAppServerPort {
+		t.Fatalf("OAuth App Server configuration = %#v", config)
+	}
+	if config.Group != "Default" || config.Root != "/" || config.ContentDatabase != "Documents" || config.ExternalSecurityName != oauthExternalSecurityName || config.TLSCertificateTemplate != "defaultTemplate" {
+		t.Fatalf("OAuth App Server configuration = %#v", config)
+	}
+}
+
+func TestKeycloakDiscoveryURL(t *testing.T) {
+	const namespace = "oauth-test"
+	baseURL := "https://keycloak.oauth-test.svc.cluster.local:8443"
+	if got := keycloakBaseURL(namespace); got != baseURL {
+		t.Fatalf("keycloakBaseURL(%q) = %q, want %q", namespace, got, baseURL)
+	}
+	want := "https://keycloak.oauth-test.svc.cluster.local:8443/realms/marklogic-oauth/.well-known/openid-configuration"
+	if got := keycloakDiscoveryURL(namespace); got != want {
+		t.Fatalf("keycloakDiscoveryURL(%q) = %q, want %q", namespace, got, want)
+	}
+}
+
+func TestMarklogicManagementURL(t *testing.T) {
+	const namespace = "oauth-test"
+	want := "https://marklogic-0.marklogic.oauth-test.svc.cluster.local:8002"
+	if got := marklogicManagementURL("marklogic", namespace); got != want {
+		t.Fatalf("marklogicManagementURL() = %q, want %q", got, want)
+	}
+}
+
+func TestInfrastructureObjectsReturnsAllRequiredResources(t *testing.T) {
+	resources, err := BuildInfrastructure(InfrastructureConfig{
+		Namespace:   oauthSessionAffinityNamespace,
+		RedirectURI: "https://oauth.example.test/callback",
+	})
+	if err != nil {
+		t.Fatalf("BuildInfrastructure returned an error: %v", err)
+	}
+	objects := resources.Objects()
+	if len(objects) != 11 {
+		t.Fatalf("object count = %d, want 11", len(objects))
+	}
+	for index, object := range objects {
+		if isNilRuntimeObject(object) {
+			t.Fatalf("object %d is nil", index)
+		}
+	}
+}
+
+func isNilRuntimeObject(object runtime.Object) bool {
+	return object == nil
+}
+
+func marklogicClusterName(resources Infrastructure) string {
+	return resources.Cluster.Name
+}
+
+func decodeCertificate(t *testing.T, secret *corev1.Secret) *x509.Certificate {
+	t.Helper()
+	certificateBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+	if certificateBlock == nil {
+		t.Fatalf("TLS Secret %q does not contain tls.crt", secret.Name)
+	}
+	certificate, err := x509.ParseCertificate(certificateBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse TLS certificate %q: %v", secret.Name, err)
+	}
+	return certificate
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/marklogic-server/oauth/session_affinity_test.go
+++ b/test/integration/marklogic-server/oauth/session_affinity_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package oauth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marklogic/marklogic-operator-kubernetes/test/integration/marklogic-server/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	sessionAffinityTestEnvironment = "MARKLOGIC_HAPROXY_SESSION_AFFINITY"
+	sessionAffinityNamespace       = "ml-haproxy-session-affinity"
+	sessionAffinityClientName      = "session-affinity-client"
+	sessionAffinityProxyName       = "session-affinity-haproxy"
+	sessionAffinityBackendAName    = "session-affinity-backend-a"
+	sessionAffinityBackendBName    = "session-affinity-backend-b"
+	sessionAffinityPort            = 8080
+
+	nginxImage   = "nginx:1.27.5-alpine"
+	haproxyImage = "haproxytech/haproxy-alpine:3.4.0"
+	curlImage    = "curlimages/curl:8.12.1"
+)
+
+func TestHAProxySessionIDAffinityContract(t *testing.T) {
+	if !sessionAffinityTestEnabledFromEnvironment() {
+		t.Skipf("set %s=true to run the HAProxy SessionID affinity contract test", sessionAffinityTestEnvironment)
+	}
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			testutil.CollectKubernetesDiagnostics(t, sessionAffinityNamespace)
+		}
+		testutil.DeleteNamespace(t, sessionAffinityNamespace)
+	})
+
+	testutil.EnsureNamespace(t, sessionAffinityNamespace)
+	testutil.ApplyObjects(t, sessionAffinityObjects(sessionAffinityNamespace)...)
+	for _, name := range []string{sessionAffinityBackendAName, sessionAffinityBackendBName, sessionAffinityProxyName} {
+		testutil.WaitForDeploymentAvailable(t, sessionAffinityNamespace, name, 2*time.Minute)
+	}
+	testutil.WaitForPodReady(t, sessionAffinityNamespace, sessionAffinityClientName, time.Minute)
+
+	initial := sessionAffinityRequest(t, "curl -sS --retry 12 --retry-delay 1 --retry-connrefused -D /tmp/headers -o /tmp/body -c /tmp/cookies -w '%{http_code}' http://"+sessionAffinityProxyName+":8080/start")
+	if initial.status != "302" {
+		t.Fatalf("initial response status = %q, want 302; headers: %s", initial.status, initial.headers)
+	}
+	if !strings.Contains(initial.headers, "SessionID=") {
+		t.Fatalf("initial response does not set SessionID: %s", initial.headers)
+	}
+	if initial.backend == "" {
+		t.Fatalf("initial response does not identify a backend: %s", initial.headers)
+	}
+
+	affine := sessionAffinityRequest(t, "curl -sS --retry 12 --retry-delay 1 --retry-connrefused -D /tmp/headers -o /tmp/body -b /tmp/cookies -w '%{http_code}' http://"+sessionAffinityProxyName+":8080/callback")
+	if affine.status != "200" {
+		t.Fatalf("cookie replay status = %q, want 200; headers: %s", affine.status, affine.headers)
+	}
+	if affine.backend != initial.backend {
+		t.Fatalf("SessionID replay backend = %q, want initiating backend %q", affine.backend, initial.backend)
+	}
+
+	backends := make(map[string]bool)
+	for request := 0; request < 8; request++ {
+		response := sessionAffinityRequest(t, "curl -sS --retry 12 --retry-delay 1 --retry-connrefused -D /tmp/headers -o /tmp/body -w '%{http_code}' http://"+sessionAffinityProxyName+":8080/callback")
+		if response.status != "200" {
+			t.Fatalf("cookie-free request %d status = %q, want 200; headers: %s", request, response.status, response.headers)
+		}
+		backends[response.backend] = true
+	}
+	if len(backends) < 2 {
+		t.Fatalf("cookie-free requests reached backends %v, want both test backends", backends)
+	}
+}
+
+type sessionAffinityResponse struct {
+	status  string
+	headers string
+	backend string
+}
+
+func sessionAffinityRequest(t *testing.T, request string) sessionAffinityResponse {
+	t.Helper()
+	testutil.ExecuteInPod(t, sessionAffinityNamespace, sessionAffinityClientName, "curl", "sh", "-ec", request+" > /tmp/status")
+	result := testutil.ExecuteInPod(t, sessionAffinityNamespace, sessionAffinityClientName, "curl", "sh", "-ec", `status=$(tail -c 3 /tmp/status 2>/dev/null || true); printf '%s\n---HEADERS---\n' "$status"; cat /tmp/headers`)
+	parts := strings.SplitN(result, "\n---HEADERS---\n", 2)
+	if len(parts) != 2 {
+		t.Fatalf("parse response metadata: %q", result)
+	}
+	return sessionAffinityResponse{
+		status:  strings.TrimSpace(parts[0]),
+		headers: parts[1],
+		backend: headerValue(parts[1], "X-Test-Backend"),
+	}
+}
+
+func sessionAffinityTestEnabledFromEnvironment() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(sessionAffinityTestEnvironment)), "true")
+}
+
+func headerValue(headers, name string) string {
+	prefix := strings.ToLower(name) + ":"
+	for _, line := range strings.Split(headers, "\n") {
+		if strings.HasPrefix(strings.ToLower(line), prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+	return ""
+}
+
+func sessionAffinityObjects(namespace string) []runtime.Object {
+	objects := []runtime.Object{
+		sessionAffinityBackendConfig(namespace, sessionAffinityBackendAName),
+		sessionAffinityBackendConfig(namespace, sessionAffinityBackendBName),
+		sessionAffinityHAProxyConfig(namespace),
+	}
+	for _, name := range []string{sessionAffinityBackendAName, sessionAffinityBackendBName} {
+		objects = append(objects, sessionAffinityBackendDeployment(namespace, name), sessionAffinityService(namespace, name))
+	}
+	objects = append(objects, sessionAffinityHAProxyDeployment(namespace), sessionAffinityService(namespace, sessionAffinityProxyName), sessionAffinityClient(namespace))
+	return objects
+}
+
+func sessionAffinityBackendConfig(namespace, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "-config", Namespace: namespace},
+		Data: map[string]string{"default.conf": fmt.Sprintf(`server {
+  listen 8080;
+  location = /start {
+    add_header Set-Cookie "SessionID=%[1]s; Path=/; HttpOnly" always;
+    add_header X-Test-Backend %[1]s always;
+    return 302 /callback;
+  }
+  location = /callback {
+    add_header X-Test-Backend %[1]s always;
+    return 200 "%[1]s\n";
+  }
+}`+"\n", name)},
+	}
+}
+
+func sessionAffinityBackendDeployment(namespace, name string) *appsv1.Deployment {
+	labels := map[string]string{"app": name}
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}, Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name: name, Image: nginxImage, Ports: []corev1.ContainerPort{{ContainerPort: sessionAffinityPort}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/etc/nginx/conf.d", ReadOnly: true}},
+			}}, Volumes: []corev1.Volume{{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: name + "-config"}}}}}}},
+		},
+	}
+}
+
+func sessionAffinityHAProxyConfig(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: sessionAffinityProxyName + "-config", Namespace: namespace},
+		Data: map[string]string{"haproxy.cfg": fmt.Sprintf(`global
+  log stdout format raw local0
+defaults
+  mode http
+  timeout connect 5s
+  timeout client 30s
+  timeout server 30s
+frontend session-affinity
+  bind :8080
+	default_backend session-affinity-backend
+backend session-affinity-backend
+  balance roundrobin
+  stick-table type string len 64 size 10k expire 5m
+  stick store-response res.cook(SessionID)
+  stick match req.cook(SessionID)
+  server node-a %[1]s:8080 check
+  server node-b %[2]s:8080 check
+`, sessionAffinityBackendAName, sessionAffinityBackendBName)},
+	}
+}
+
+func sessionAffinityHAProxyDeployment(namespace string) *appsv1.Deployment {
+	labels := map[string]string{"app": sessionAffinityProxyName}
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: sessionAffinityProxyName, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}, Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name: "haproxy", Image: haproxyImage, Ports: []corev1.ContainerPort{{ContainerPort: sessionAffinityPort}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/usr/local/etc/haproxy/haproxy.cfg", SubPath: "haproxy.cfg", ReadOnly: true}},
+			}}, Volumes: []corev1.Volume{{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: sessionAffinityProxyName + "-config"}}}}}}},
+		},
+	}
+}
+
+func sessionAffinityService(namespace, name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": name}, Ports: []corev1.ServicePort{{Port: sessionAffinityPort, TargetPort: intstr.FromInt(sessionAffinityPort)}}},
+	}
+}
+
+func sessionAffinityClient(namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: sessionAffinityClientName, Namespace: namespace},
+		Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever, Containers: []corev1.Container{{Name: "curl", Image: curlImage, Command: []string{"sleep", "infinity"}}}},
+	}
+}

--- a/test/integration/marklogic-server/testutil/kubernetes.go
+++ b/test/integration/marklogic-server/testutil/kubernetes.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+var integrationScheme = newIntegrationScheme()
+
+func newIntegrationScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(marklogicv1.AddToScheme(scheme))
+	return scheme
+}
+
+// CollectKubernetesDiagnostics logs non-secret resources and container logs for a failed test namespace.
+func CollectKubernetesDiagnostics(t *testing.T, namespace string) {
+	t.Helper()
+	commands := [][]string{
+		{"get", "pods,services,ingresses", "-n", namespace, "-o", "wide"},
+		{"get", "events", "-n", namespace, "--sort-by=.lastTimestamp"},
+		{"get", "pods", "-n", namespace, "-o", "yaml"},
+	}
+	for _, arguments := range commands {
+		output, err := runKubectl(arguments...)
+		if err != nil {
+			t.Logf("Kubernetes diagnostics command %q failed: %v\n%s", arguments, err, output)
+			continue
+		}
+		t.Logf("Kubernetes diagnostics command %q:\n%s", arguments, output)
+	}
+
+	pods, err := runKubectl("get", "pods", "-n", namespace, "-o", "name")
+	if err != nil {
+		t.Logf("Unable to list pods for diagnostics: %v\n%s", err, pods)
+		return
+	}
+	for _, pod := range nonEmptyLines(pods) {
+		output, err := runKubectl("logs", "-n", namespace, pod, "--all-containers", "--tail=500")
+		if err != nil {
+			t.Logf("Kubernetes diagnostics for %s failed: %v\n%s", pod, err, output)
+			continue
+		}
+		t.Logf("Kubernetes diagnostics for %s:\n%s", pod, output)
+	}
+}
+
+// DeleteNamespace requests asynchronous cleanup so failed test evidence remains available in test logs.
+func DeleteNamespace(t *testing.T, namespace string) {
+	t.Helper()
+	output, err := runKubectl("delete", "namespace", namespace, "--ignore-not-found", "--wait=false")
+	if err != nil {
+		t.Logf("Namespace cleanup for %s failed: %v\n%s", namespace, err, output)
+	}
+}
+
+// EnsureNamespace creates the namespace if it does not already exist.
+func EnsureNamespace(t *testing.T, namespace string) {
+	t.Helper()
+	output, err := runKubectl("create", "namespace", namespace)
+	if err != nil && !strings.Contains(output, "AlreadyExists") {
+		t.Fatalf("Create namespace %s: %v\n%s", namespace, err, output)
+	}
+}
+
+// ApplyObjects applies typed Kubernetes resources through kubectl.
+func ApplyObjects(t *testing.T, objects ...runtime.Object) {
+	t.Helper()
+	var manifest bytes.Buffer
+	for index, object := range objects {
+		if object == nil {
+			t.Fatal("Cannot apply a nil Kubernetes object")
+		}
+		if index > 0 {
+			manifest.WriteString("\n---\n")
+		}
+		contents, err := marshalKubernetesObject(object)
+		if err != nil {
+			t.Fatalf("Marshal Kubernetes object %T: %v", object, err)
+		}
+		manifest.Write(contents)
+	}
+	output, err := runKubectlInput(manifest.Bytes(), "apply", "-f", "-")
+	if err != nil {
+		t.Fatalf("Apply Kubernetes resources: %v\n%s", err, output)
+	}
+}
+
+func marshalKubernetesObject(object runtime.Object) ([]byte, error) {
+	gvks, _, err := integrationScheme.ObjectKinds(object)
+	if err != nil {
+		return nil, err
+	}
+	if len(gvks) != 1 {
+		return nil, fmt.Errorf("expected exactly one GroupVersionKind, got %d", len(gvks))
+	}
+	copy := object.DeepCopyObject()
+	copy.GetObjectKind().SetGroupVersionKind(gvks[0])
+	return json.Marshal(copy)
+}
+
+// WaitForDeploymentAvailable waits for Kubernetes to report a Deployment as available.
+func WaitForDeploymentAvailable(t *testing.T, namespace, name string, timeout time.Duration) {
+	t.Helper()
+	waitForResourceCreation(t, namespace, "deployment", name, timeout)
+	output, err := runKubectl("rollout", "status", "deployment/"+name, "-n", namespace, "--timeout="+timeout.String())
+	if err != nil {
+		t.Fatalf("Wait for deployment %s/%s: %v\n%s", namespace, name, err, output)
+	}
+}
+
+func WaitForStatefulSetReady(t *testing.T, namespace, name string, timeout time.Duration) {
+	t.Helper()
+	waitForResourceCreation(t, namespace, "statefulset", name, timeout)
+	replicas, err := runKubectl("get", "statefulset/"+name, "-n", namespace, "-o", "jsonpath={.spec.replicas}")
+	if err != nil {
+		t.Fatalf("Get StatefulSet %s/%s replicas: %v\n%s", namespace, name, err, replicas)
+	}
+	expectedReplicas, err := strconv.Atoi(strings.TrimSpace(replicas))
+	if err != nil || expectedReplicas < 1 {
+		t.Fatalf("StatefulSet %s/%s replicas = %q, want a positive integer", namespace, name, replicas)
+	}
+	output, err := runKubectl("wait", "--for=jsonpath={.status.readyReplicas}="+strconv.Itoa(expectedReplicas), "statefulset/"+name, "-n", namespace, "--timeout="+timeout.String())
+	if err != nil {
+		t.Fatalf("Wait for StatefulSet %s/%s ready replicas: %v\n%s", namespace, name, err, output)
+	}
+}
+
+func WaitForPodReady(t *testing.T, namespace, name string, timeout time.Duration) {
+	t.Helper()
+	output, err := runKubectl("wait", "--for=condition=Ready", "pod/"+name, "-n", namespace, "--timeout="+timeout.String())
+	if err != nil {
+		t.Fatalf("Wait for Pod %s/%s: %v\n%s", namespace, name, err, output)
+	}
+}
+
+func waitForResourceCreation(t *testing.T, namespace, resource, name string, timeout time.Duration) {
+	t.Helper()
+	output, err := runKubectl("wait", "--for=create", resource+"/"+name, "-n", namespace, "--timeout="+timeout.String())
+	if err != nil {
+		t.Fatalf("Wait for %s %s/%s creation: %v\n%s", resource, namespace, name, err, output)
+	}
+}
+
+// ExecuteInPod runs a command in a ready Pod container and returns its combined output.
+func ExecuteInPod(t *testing.T, namespace, name, container string, command ...string) string {
+	t.Helper()
+	arguments := []string{"exec", "pod/" + name, "-n", namespace}
+	if container != "" {
+		arguments = append(arguments, "-c", container)
+	}
+	arguments = append(arguments, "--")
+	arguments = append(arguments, command...)
+	output, err := runKubectl(arguments...)
+	if err != nil {
+		t.Fatalf("Execute command in Pod %s/%s: %v\n%s", namespace, name, err, output)
+	}
+	return output
+}
+
+func runKubectl(arguments ...string) (string, error) {
+	command := exec.Command("kubectl", arguments...)
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func runKubectlInput(input []byte, arguments ...string) (string, error) {
+	command := exec.Command("kubectl", arguments...)
+	command.Stdin = bytes.NewReader(input)
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func nonEmptyLines(value string) []string {
+	var lines []string
+	for _, line := range strings.Split(value, "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/test/integration/marklogic-server/testutil/kubernetes_test.go
+++ b/test/integration/marklogic-server/testutil/kubernetes_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
+package testutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	marklogicv1 "github.com/marklogic/marklogic-operator-kubernetes/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMarshalKubernetesObjectAddsGroupVersionKind(t *testing.T) {
+	testCases := []struct {
+		name       string
+		object     runtime.Object
+		apiVersion string
+		kind       string
+	}{
+		{
+			name:       "core secret",
+			object:     &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-secret"}},
+			apiVersion: "v1",
+			kind:       "Secret",
+		},
+		{
+			name:       "apps deployment",
+			object:     &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"}},
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+		},
+		{
+			name:       "MarkLogic cluster",
+			object:     &marklogicv1.MarklogicCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}},
+			apiVersion: "marklogic.progress.com/v1",
+			kind:       "MarklogicCluster",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			contents, err := marshalKubernetesObject(testCase.object)
+			if err != nil {
+				t.Fatalf("marshalKubernetesObject returned an error: %v", err)
+			}
+			var manifest map[string]any
+			if err := json.Unmarshal(contents, &manifest); err != nil {
+				t.Fatalf("decode manifest: %v", err)
+			}
+			if manifest["apiVersion"] != testCase.apiVersion {
+				t.Fatalf("apiVersion = %q, want %q", manifest["apiVersion"], testCase.apiVersion)
+			}
+			if manifest["kind"] != testCase.kind {
+				t.Fatalf("kind = %q, want %q", manifest["kind"], testCase.kind)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Add OAuth Authorization Code flow support with HAProxy session affinity, plus full integration test suite

### Summary
Adds Management API support for configuring MarkLogic OAuth (external security + OAuth-protected App Servers), fixes a MarkLogic 12.1 bootstrap readiness check, mounts the SSL certificate into the HAProxy container for TLS-terminated OAuth callbacks, and adds a comprehensive integration test suite validating the OAuth Authorization Code flow and HAProxy session affinity end-to-end (validated on both minikube and a real multi-node AWS EKS cluster).

### Changes

**pkg/mlmanage/client.go / client_test.go**
- New `Client` interface methods:
  - `ImportCertificateAuthority` - imports a PEM-encoded CA into the Security database (new `doPlainText` request helper).
  - `EnsureOAuthExternalSecurity` - idempotently creates/updates an `external-security` OAuth config (`oauth-server` block: flow type, vendor, client ID/secret, token/authorization server URIs, JWT issuer/algorithm/JWKS, username/role attributes).
  - `EnsureOAuthAppServer` - idempotently creates/updates an OAuth-protected HTTP App Server (`authentication=oauth`, `external-security`, TLS certificate template).
- Added config structs (`OAuthExternalSecurityConfig`, `OAuthAppServerConfig`) with validation, and payload builders (`BuildOAuthExternalSecurityPayload`, `BuildOAuthAppServerPayload`).
- Optional OAuth fields (client secret, redirect URI, JWT issuer URI) are only included in the payload when non-empty, avoiding unintentionally clearing existing values on update.

**pkg/k8sutil/haProxy.go**
- Mounts the `ssl-certificate` volume (read-only) into the HAProxy container at `/usr/local/etc/ssl`, required for HAProxy to terminate/forward TLS for the OAuth Authorization Code callback path.

**pkg/k8sutil/scripts/cluster-config.sh**
- Fixes `wait_bootstrap_ready` for MarkLogic 12.1+: the TLS-enabled bootstrap host now returns `500 XDMP-NOUSER` instead of `403` when queried unauthenticated. The check now accepts either signal (403, or 500 with `XDMP-NOUSER` body) as "ready," with proper temp-file cleanup for the captured response body.

**Test doubles**
- `internal/controller/marklogicgroup_controller_test.go` and `pkg/k8sutil/dynamic_reconcile_test.go`: updated fake/stub management clients to implement the three new `Client` interface methods.

**New integration test suite (test/integration/marklogic-server/)**
- `fixtures/keycloak`, `fixtures/tls`, `fixtures/marklogiccluster`, `fixtures/oauthclient`: reusable fixtures for standing up Keycloak (public/confidential clients), TLS certs, a MarklogicCluster, and an in-cluster OAuth test client pod.
- `testutil/kubernetes.go`: shared Kubernetes test helpers.
- `oauth/oauth_setup.go` + `oauth_setup_test.go`: wires up MarkLogic OAuth external security/App Server, Keycloak realm, and HAProxy for Authorization Code testing.
- `oauth/oauth_authorization_code_test.go`: `TestOAuthAuthorizationCodeInfrastructure` - TC1 (SessionID issued before authentication), TC2 (HAProxy affinity completes the flow), TC3 (bypassing HAProxy / cross-node callback is correctly rejected as a potential CSRF/state mismatch).
- `oauth/session_affinity_test.go`, `oauth/oauth_load_balancer_affinity_test.go`: additional HAProxy session-affinity coverage.
- README.md (top-level integration dir) and oauth/README.md: document suite layout, prerequisites, env vars, and how to run each test group.

### Testing
- `go test -v -run TestOAuthAuthorizationCodeInfrastructure ./test/integration/marklogic-server/oauth` - all 3 subtests pass on minikube.
- Re-validated on a real AWS EKS cluster (2-node, MarkLogic 12.1, operator built for linux/amd64, images via ECR):
  - TC1_SessionID_before_authentication - PASS
  - TC2_affinity_completes_flow - PASS
  - TC3_cross_node_callback_fails - PASS (correctly returns `500 XDMP-OAUTH: Novel OAuth state... potential CSRF attack` when affinity is bypassed)
  - Confirms the flow relies only on the operator-managed in-cluster HAProxy ClusterIP service - no AWS ALB/NLB required.
