### PR TITLE
MLE-31809 Remediate Security Issues in Code for Operator 1.3.1 Release

### DIFF
--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -404,7 +404,7 @@ func (c *managementClient) RequestDynamicHostToken(ctx context.Context, clusterN
 	return token, nil
 }
 
-func (c *managementClient) JoinDynamicHost(ctx context.Context, hostFQDN, token string) (err error) {
+func (c *managementClient) JoinDynamicHost(ctx context.Context, hostFQDN, token string) error {
 	scheme := "http"
 	if strings.HasPrefix(c.baseURL, "https://") {
 		scheme = "https"
@@ -427,13 +427,14 @@ func (c *managementClient) JoinDynamicHost(ctx context.Context, hostFQDN, token 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		err = errors.Join(err, resp.Body.Close())
-	}()
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
+	respBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return errors.Join(readErr, closeErr)
+	}
+	if closeErr != nil {
+		return closeErr
 	}
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
 		return nil
@@ -675,13 +676,14 @@ func (c *managementClient) doJSON(ctx context.Context, method, path string, quer
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() {
-		err = errors.Join(err, resp.Body.Close())
-	}()
 
-	data, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, resp.StatusCode, err
+	data, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
+	}
+	if closeErr != nil {
+		return data, resp.StatusCode, closeErr
 	}
 	statusCode = resp.StatusCode
 
@@ -713,13 +715,14 @@ func (c *managementClient) doXML(ctx context.Context, method, path string, query
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() {
-		err = errors.Join(err, resp.Body.Close())
-	}()
 
-	data, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, resp.StatusCode, err
+	data, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
+	}
+	if closeErr != nil {
+		return data, resp.StatusCode, closeErr
 	}
 	statusCode = resp.StatusCode
 
@@ -742,13 +745,14 @@ func (c *managementClient) doPlainText(ctx context.Context, method, path string,
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() {
-		err = errors.Join(err, resp.Body.Close())
-	}()
 
-	data, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, resp.StatusCode, err
+	data, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
+	}
+	if closeErr != nil {
+		return data, resp.StatusCode, closeErr
 	}
 	statusCode = resp.StatusCode
 	for _, code := range expectedStatus {

--- a/pkg/mlmanage/client.go
+++ b/pkg/mlmanage/client.go
@@ -433,14 +433,14 @@ func (c *managementClient) JoinDynamicHost(ctx context.Context, hostFQDN, token 
 	if readErr != nil {
 		return errors.Join(readErr, closeErr)
 	}
-	if closeErr != nil {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
 		return closeErr
 	}
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
-		return nil
-	}
 
-	return fmt.Errorf("dynamic host init POST /admin/v1/init returned status %d: %s", resp.StatusCode, string(respBody))
+	return errors.Join(
+		fmt.Errorf("dynamic host init POST /admin/v1/init returned status %d: %s", resp.StatusCode, string(respBody)),
+		closeErr,
+	)
 }
 
 func (c *managementClient) ListGroupHosts(ctx context.Context, groupName string) ([]GroupHost, error) {
@@ -682,17 +682,16 @@ func (c *managementClient) doJSON(ctx context.Context, method, path string, quer
 	if readErr != nil {
 		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
 	}
-	if closeErr != nil {
-		return data, resp.StatusCode, closeErr
-	}
-	statusCode = resp.StatusCode
 
 	for _, code := range expectedStatus {
 		if resp.StatusCode == code {
-			return data, resp.StatusCode, nil
+			return data, resp.StatusCode, closeErr
 		}
 	}
-	return data, resp.StatusCode, fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data))
+	return data, resp.StatusCode, errors.Join(
+		fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data)),
+		closeErr,
+	)
 }
 
 func (c *managementClient) doXML(ctx context.Context, method, path string, query url.Values, body string, expectedStatus ...int) (data []byte, statusCode int, err error) {
@@ -721,17 +720,16 @@ func (c *managementClient) doXML(ctx context.Context, method, path string, query
 	if readErr != nil {
 		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
 	}
-	if closeErr != nil {
-		return data, resp.StatusCode, closeErr
-	}
-	statusCode = resp.StatusCode
 
 	for _, code := range expectedStatus {
 		if resp.StatusCode == code {
-			return data, resp.StatusCode, nil
+			return data, resp.StatusCode, closeErr
 		}
 	}
-	return data, resp.StatusCode, fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data))
+	return data, resp.StatusCode, errors.Join(
+		fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data)),
+		closeErr,
+	)
 }
 
 func (c *managementClient) doPlainText(ctx context.Context, method, path string, query url.Values, body string, expectedStatus ...int) (data []byte, statusCode int, err error) {
@@ -751,16 +749,15 @@ func (c *managementClient) doPlainText(ctx context.Context, method, path string,
 	if readErr != nil {
 		return nil, resp.StatusCode, errors.Join(readErr, closeErr)
 	}
-	if closeErr != nil {
-		return data, resp.StatusCode, closeErr
-	}
-	statusCode = resp.StatusCode
 	for _, code := range expectedStatus {
 		if resp.StatusCode == code {
-			return data, resp.StatusCode, nil
+			return data, resp.StatusCode, closeErr
 		}
 	}
-	return data, resp.StatusCode, fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data))
+	return data, resp.StatusCode, errors.Join(
+		fmt.Errorf("management api %s %s returned status %d: %s", method, path, resp.StatusCode, string(data)),
+		closeErr,
+	)
 }
 
 func (c *managementClient) doRequestWithAuth(ctx context.Context, method, endpoint string, headers map[string]string, body []byte) (*http.Response, error) {

--- a/pkg/mlmanage/client_test.go
+++ b/pkg/mlmanage/client_test.go
@@ -6,12 +6,113 @@ import (
 	"context"
 	"crypto"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type closeErrorReadCloser struct {
+	io.Reader
+	err error
+}
+
+func (body closeErrorReadCloser) Close() error {
+	return body.err
+}
+
+func TestJoinDynamicHostPreservesHTTPAndCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close response body")
+	client := &managementClient{
+		baseURL: "http://management.example.test",
+		httpClient: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       closeErrorReadCloser{Reader: strings.NewReader("invalid dynamic host token"), err: closeErr},
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	err := client.JoinDynamicHost(context.Background(), "node-1.example.test", "token")
+	if err == nil {
+		t.Fatal("expected JoinDynamicHost to return an error")
+	}
+	if !strings.Contains(err.Error(), "returned status 400: invalid dynamic host token") {
+		t.Fatalf("expected HTTP status error, got %v", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected joined close error, got %v", err)
+	}
+}
+
+func TestResponseHelpersPreserveHTTPAndCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(*managementClient) ([]byte, int, error)
+	}{
+		{
+			name: "JSON",
+			call: func(client *managementClient) ([]byte, int, error) {
+				return client.doJSON(context.Background(), http.MethodGet, "/manage/v2", nil, nil, http.StatusOK)
+			},
+		},
+		{
+			name: "XML",
+			call: func(client *managementClient) ([]byte, int, error) {
+				return client.doXML(context.Background(), http.MethodGet, "/manage/v2", nil, "", http.StatusOK)
+			},
+		},
+		{
+			name: "PlainText",
+			call: func(client *managementClient) ([]byte, int, error) {
+				return client.doPlainText(context.Background(), http.MethodPost, "/manage/v2/certificate-authorities", nil, "", http.StatusCreated)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			closeErr := errors.New("close response body")
+			client := &managementClient{
+				baseURL: "http://management.example.test",
+				httpClient: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       closeErrorReadCloser{Reader: strings.NewReader("management failure"), err: closeErr},
+						Header:     make(http.Header),
+					}, nil
+				})},
+			}
+
+			_, statusCode, err := test.call(client)
+			if statusCode != http.StatusInternalServerError {
+				t.Fatalf("status code = %d, want %d", statusCode, http.StatusInternalServerError)
+			}
+			if err == nil {
+				t.Fatal("expected response helper to return an error")
+			}
+			if !strings.Contains(err.Error(), "returned status 500: management failure") {
+				t.Fatalf("expected HTTP status error, got %v", err)
+			}
+			if !errors.Is(err, closeErr) {
+				t.Fatalf("expected joined close error, got %v", err)
+			}
+		})
+	}
+}
 
 func TestRemoveDynamicHostUsesXMLBodyContract(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes Polaris `CWE-563: Assignment to Variable without Use` findings in `pkg/mlmanage/client.go`.

Response-body handling no longer assigns close errors to a deferred named return variable. Each affected request path now explicitly reads and closes the response body, returning read or close errors as appropriate.

## Changes

- Updated `JoinDynamicHost` response-body handling.
- Updated shared `doJSON`, `doXML`, and `doPlainText` helpers.
- Preserved error propagation when reading or closing HTTP response bodies.
